### PR TITLE
Use write-verbose, UTF8 encoding

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ environment:
         - SUBLIME_TEXT_VERSION : "3"
 
 install:
-    - ps: .\sbin\appveyor.ps1 "bootstrap"
+    - ps: .\sbin\appveyor.ps1 "bootstrap" -verbose
 
 build: off
 
 test_script:
-    - ps: .\sbin\appveyor.ps1 "run_tests"
+    - ps: .\sbin\appveyor.ps1 "run_tests" -verbose

--- a/sbin/appveyor.ps1
+++ b/sbin/appveyor.ps1
@@ -1,15 +1,16 @@
+[CmdletBinding()]
 param([string]$command)
 
 Function Bootstrap {
     if ( ${env:SUBLIME_TEXT_VERSION} -eq "3" ){
-        write-output "installing sublime text 3"
+        write-verbose "installing sublime text 3"
         start-filedownload "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203065%20x64.zip"
-        write-output "installing Sublime%20Text%20Build%203065%20x64.zip"
+        write-verbose "installing Sublime%20Text%20Build%203065%20x64.zip"
         7z.exe x "Sublime%20Text%20Build%203065%20x64.zip" -o"C:\st" > $null
     }elseif ( ${env:SUBLIME_TEXT_VERSION} -eq "2" ){
-        write-output "installing sublime text 2"
+        write-verbose "installing sublime text 2"
         start-filedownload "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2%20x64.zip"
-        write-output "installing Sublime%20Text%202.0.2%20x64.zip"
+        write-verbose "installing Sublime%20Text%202.0.2%20x64.zip"
         7z.exe x "Sublime%20Text%202.0.2%20x64.zip" -o"C:\st" > $null
     }
 
@@ -29,7 +30,7 @@ Function Bootstrap {
 }
 
 Function RunTests {
-    C:\st\Data\Packages\UnitTesting\sbin\run.ps1 "${env:PACKAGE}"
+    & "C:\st\Data\Packages\UnitTesting\sbin\run.ps1" "${env:PACKAGE}" -verbose
 }
 
 switch ($command){


### PR DESCRIPTION
- Enable verbose streams via `-verbose` flag.
- Use `CmdletBinding` attribute to hook script up with cmdlet param processing
- Use UTF8 encoding (without preamble)
