### PR TITLE
fix ValueError when using format in python 2

### DIFF
--- a/unittesting/loader.py
+++ b/unittesting/loader.py
@@ -22,7 +22,7 @@ VALID_MODULE_NAME = re.compile(r'[_a-z]\w*\.py$', re.IGNORECASE)
 
 
 def _make_failed_import_test(name, suiteClass):
-    message = 'Failed to import test module: {}\n{}'.format(
+    message = 'Failed to import test module: {0}\n{1}'.format(
         name, traceback.format_exc()
     )
     return _make_failed_test(


### PR DESCRIPTION
In Python 2 (and thus in Sublime Text 2) an error occurs when trying to format the "failed import message". The occurring error was "ValueError: zero length field name in format".
