### PR TITLE
Added the sys.stdout and sys.stderr to the Sublime Text console

### DIFF
--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -119,10 +119,12 @@ class UnitTestingMixin(object):
         outfile = os.path.join(outputdir, package)
         return outfile
 
-    def load_stream(self, package, output):
+    def load_stream(self, package, settings):
+        output = settings["output"]
+        capture_console = settings["capture_console"]
         if not output or output == "<panel>":
             output_panel = OutputPanel(
-                'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)')
+                'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)', capture_console=capture_console)
             output_panel.show()
             stream = output_panel
         else:

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -121,10 +121,9 @@ class UnitTestingMixin(object):
 
     def load_stream(self, package, settings):
         output = settings["output"]
-        capture_console = settings["capture_console"]
         if not output or output == "<panel>":
             output_panel = OutputPanel(
-                'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)', capture_console=capture_console)
+                'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)')
             output_panel.show()
             stream = output_panel
         else:

--- a/unittesting/test_color_scheme.py
+++ b/unittesting/test_color_scheme.py
@@ -12,7 +12,7 @@ class UnitTestingColorSchemeCommand(ApplicationCommand, UnitTestingMixin):
 
         window = sublime.active_window()
         settings = self.load_unittesting_settings(package, **kargs)
-        stream = self.load_stream(package, settings["output"])
+        stream = self.load_stream(package, settings)
 
         try:
             from ColorSchemeUnit.lib.runner import ColorSchemeUnit

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -22,7 +22,7 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
 
         package, pattern = self.input_parser(package)
         settings = self.load_unittesting_settings(package, pattern=pattern, **kargs)
-        stream = self.load_stream(package, settings["output"])
+        stream = self.load_stream(package, settings)
 
         if settings["async"]:
             threading.Thread(target=lambda: self.unit_testing(stream, package, settings)).start()
@@ -37,10 +37,10 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                 raise Exception("DeferrableTestCase is used but `deferred` is `false`.")
 
     def unit_testing(self, stream, package, settings, cleanup_hooks=[]):
-        stdout = sys.stdout
-        stderr = sys.stderr
-        handler = logging.StreamHandler(stream)
         if settings["capture_console"]:
+            stdout = sys.stdout
+            stderr = sys.stderr
+            handler = logging.StreamHandler(stream)
             logging.root.addHandler(handler)
             sys.stdout = stream
             sys.stderr = stream

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -48,14 +48,16 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                     stdout.write(data)
                     stream.write(data)
                 def flush(self):
-                    pass
+                    stderr.flush()
+                    stream.flush()
 
             class StdErrForward(object):
                 def write(self, data):
                     stderr.write(data)
                     stream.write(data)
                 def flush(self):
-                    pass
+                    stderr.flush()
+                    stream.flush()
 
             sys.stdout = StdOutForward()
             sys.stderr = StdErrForward()

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -42,8 +42,23 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
             stderr = sys.stderr
             handler = logging.StreamHandler(stream)
             logging.root.addHandler(handler)
-            sys.stdout = stream
-            sys.stderr = stream
+
+            class StdOutForward(object):
+                def write(self, data):
+                    stdout.write(data)
+                    stream.write(data)
+                def flush(self):
+                    pass
+
+            class StdErrForward(object):
+                def write(self, data):
+                    stderr.write(data)
+                    stream.write(data)
+                def flush(self):
+                    pass
+
+            sys.stdout = StdOutForward()
+            sys.stderr = StdErrForward()
         testRunner = None
         progress_bar = ProgressBar("Testing %s" % package)
         progress_bar.start()

--- a/unittesting/test_syntax.py
+++ b/unittesting/test_syntax.py
@@ -16,7 +16,7 @@ class UnitTestingSyntaxCommand(sublime_plugin.ApplicationCommand, UnitTestingMix
         if not package:
             return
         settings = self.load_unittesting_settings(package, **kargs)
-        stream = self.load_stream(package, settings["output"])
+        stream = self.load_stream(package, settings)
 
         self.syntax_testing(stream, package)
 

--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -8,7 +8,8 @@ class OutputPanel:
     def __init__(
         self, name, file_regex='', line_regex='', base_dir=None,
         word_wrap=False, line_numbers=False, gutter=False,
-        scroll_past_end=False, syntax='Packages/Text/Plain text.tmLanguage'
+        scroll_past_end=False, syntax='Packages/Text/Plain text.tmLanguage',
+        capture_console=False
     ):
         self.name = name
         self.window = sublime.active_window()
@@ -29,7 +30,10 @@ class OutputPanel:
         settings.set("scroll_past_end", scroll_past_end)
         settings.set("syntax", syntax)
         self.closed = False
-        self._stderr = sys.stderr
+        if capture_console:
+            self._stderr = sys.stderr
+        else:
+            self._stderr = lambda s: s
 
     def write(self, s):
         self._stderr.write(s)

--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -1,5 +1,6 @@
 import sublime
 import os
+import sys
 
 
 class OutputPanel:
@@ -28,8 +29,10 @@ class OutputPanel:
         settings.set("scroll_past_end", scroll_past_end)
         settings.set("syntax", syntax)
         self.closed = False
+        self._stderr = sys.stderr
 
     def write(self, s):
+        self._stderr.write(s)
         self.output_view.set_read_only(False)
         self.output_view.run_command('append', {'characters': s}),
         self.output_view.set_read_only(True)

--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -8,8 +8,7 @@ class OutputPanel:
     def __init__(
         self, name, file_regex='', line_regex='', base_dir=None,
         word_wrap=False, line_numbers=False, gutter=False,
-        scroll_past_end=False, syntax='Packages/Text/Plain text.tmLanguage',
-        capture_console=False
+        scroll_past_end=False, syntax='Packages/Text/Plain text.tmLanguage'
     ):
         self.name = name
         self.window = sublime.active_window()
@@ -30,13 +29,8 @@ class OutputPanel:
         settings.set("scroll_past_end", scroll_past_end)
         settings.set("syntax", syntax)
         self.closed = False
-        if capture_console:
-            self._stderr = sys.stderr.write
-        else:
-            self._stderr = lambda s: s
 
     def write(self, s):
-        self._stderr(s)
         self.output_view.set_read_only(False)
         self.output_view.run_command('append', {'characters': s}),
         self.output_view.set_read_only(True)

--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -31,12 +31,12 @@ class OutputPanel:
         settings.set("syntax", syntax)
         self.closed = False
         if capture_console:
-            self._stderr = sys.stderr
+            self._stderr = sys.stderr.write
         else:
             self._stderr = lambda s: s
 
     def write(self, s):
-        self._stderr.write(s)
+        self._stderr(s)
         self.output_view.set_read_only(False)
         self.output_view.run_command('append', {'characters': s}),
         self.output_view.set_read_only(True)


### PR DESCRIPTION
I did some Unit Tests for [my dependency](https://ci.appveyor.com/project/evandrocoan/pythondebugtools) which capture `sys.stderr` contents and send them to a logging file. But as I am using the panel feature, the UnitTesting package replaces `sys.stderr` and `sys.stdout` by his own `OutputPanel` object, which ommits the outputs to the original streams `sys.stdout` and `sys.stderr`.

I could not figure out a simple way to keep capturing `stderr` and `stdout` while sending them to their original streams `sys.__stderr__` and `sys.__stdout__`. But just sending everything to `stderr` also solves it.
