### PR TITLE
Fix Travis OSX error updating python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
     - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
             brew update;
-            brew install python3;
+            brew upgrade python;
       fi
     - pip3 install flake8;
     - pip3 install flake8-docstrings;


### PR DESCRIPTION
The next time you run the tests on travis you'll probably get the following error. This patch will fix it. I don't really understand the underlying issue, but the patch fixes it.

```
Error: python 2.7.14 is already installed
To upgrade to 3.6.4_3, run `brew upgrade python`
/Users/travis/.travis/job_stages: line 57: pip3: command not found
/Users/travis/.travis/job_stages: line 57: pip3: command not found
/Users/travis/.travis/job_stages: line 57: pip3: command not found
The command "if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install
flake8; pip install flake8-docstrings; pip install python-coveralls;
elif [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; brew install
python3; pip3 install flake8; pip3 install flake8-docstrings; pip3
install python-coveralls; fi" failed and exited with 127 during .
```