### PR TITLE
Fix subpackage imports.

### DIFF
--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -8,7 +8,6 @@ from .test_current import UnitTestingCurrentPackageCommand
 from .test_current import UnitTestingCurrentPackageCoverageCommand
 from .test_syntax import UnitTestingSyntaxCommand
 from .test_color_scheme import UnitTestingColorSchemeCommand
-from . import helpers  # FIXME is this required to be imported? # noqa: F401
 
 
 __all__ = [

--- a/ut.py
+++ b/ut.py
@@ -15,8 +15,12 @@ if os.path.exists(coverage_path) and coverage_path not in sys.path:
     sys.path.append(coverage_path)
 
 from . import unittesting  # noqa: F402
+from .unittesting import utils  # noqa: F402
+from .unittesting import helpers  # noqa: F402
 
 sys.modules["unittesting"] = unittesting
+sys.modules["unittesting.utils"] = utils
+sys.modules["unittesting.helpers"] = helpers
 
 from unittesting import UnitTestingRunSchedulerCommand  # noqa: F401
 from unittesting import UnitTestingCommand  # noqa: F401


### PR DESCRIPTION
I couldn't get the package tests to pass, and it looks like the culprit was the way that subpackages were being imported. I believe that this way is correct; at least, it makes the tests pass.

The cleanest way to expose a `unittesting` module for importing by other packages would be to create a `unittesting` dependency.