### PR TITLE
Removed unused version and platform variables.

### DIFF
--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -11,7 +11,6 @@ from .utils import ProgressBar
 
 import sublime
 
-version = sublime.version()
 platform = sublime.platform()
 
 

--- a/unittesting/test_coverage.py
+++ b/unittesting/test_coverage.py
@@ -4,9 +4,6 @@ import sys
 import re
 from .test_package import UnitTestingCommand
 
-version = sublime.version()
-platform = sublime.platform()
-
 try:
     import coverage
 except Exception:

--- a/unittesting/test_current.py
+++ b/unittesting/test_current.py
@@ -3,9 +3,6 @@ import sys
 from .test_package import UnitTestingCommand
 from .test_coverage import UnitTestingCoverageCommand
 
-version = sublime.version()
-platform = sublime.platform()
-
 
 class UnitTestingCurrentPackageCommand(UnitTestingCommand):
     def run(self):

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -10,8 +10,6 @@ from .const import DONE_MESSAGE
 from .utils import ProgressBar, StdioSplitter
 import threading
 
-version = sublime.version()
-
 
 class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
 


### PR DESCRIPTION
`sublime.version()` and `sublime.platform()` are still used in some places. Where `platform` is used for path stuff, the `os.path` module should probably be used instead.

Is ST2 still supported? If it's supported in theory, then do the tests cover it in practice? There's a fair chunk of ST2-specific code laying around.