### PR TITLE
Reload package if user opted in

### DIFF
--- a/unittesting/test_coverage.py
+++ b/unittesting/test_coverage.py
@@ -37,8 +37,6 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
         cov = coverage.Coverage(
             data_file=data_file, config_file=config_file, include=include, omit=omit)
         cov.start()
-        if settings["reload_package_on_testing"]:
-            self.reload_package(package, dummy=False, show_reload_progress=False)
 
         def cleanup():
             stream.write("\n")

--- a/unittesting/test_current.py
+++ b/unittesting/test_current.py
@@ -14,13 +14,6 @@ class UnitTestingCurrentPackageCommand(UnitTestingCommand):
         sublime.set_timeout_async(
             lambda: super(UnitTestingCurrentPackageCommand, self).run(project_name))
 
-    def unit_testing(self, stream, package, settings):
-        parent = super(UnitTestingCurrentPackageCommand, self)
-        if settings["reload_package_on_testing"]:
-            self.reload_package(
-                package, dummy=True, show_reload_progress=settings["show_reload_progress"])
-        parent.unit_testing(stream, package, settings)
-
 
 class UnitTestingCurrentPackageCoverageCommand(UnitTestingCoverageCommand):
 
@@ -30,7 +23,8 @@ class UnitTestingCurrentPackageCoverageCommand(UnitTestingCoverageCommand):
             sublime.message_dialog("Cannot determine package name.")
             return
 
-        super(UnitTestingCurrentPackageCoverageCommand, self).run(project_name)
+        sublime.set_timeout_async(
+            super(UnitTestingCurrentPackageCoverageCommand, self).run(project_name))
 
     def is_enabled(self):
         return "coverage" in sys.modules
@@ -47,4 +41,5 @@ class UnitTestingCurrentFileCommand(UnitTestingCommand):
         if not test_file:
             test_file = ""
 
-        super(UnitTestingCurrentFileCommand, self).run("{}:{}".format(project_name, test_file))
+        sublime.set_timeout_async(
+            lambda: super(UnitTestingCurrentFileCommand, self).run("{}:{}".format(project_name, test_file)))

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -35,6 +35,10 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                 raise Exception("DeferrableTestCase is used but `deferred` is `false`.")
 
     def unit_testing(self, stream, package, settings, cleanup_hooks=[]):
+        if settings["reload_package_on_testing"]:
+            self.reload_package(
+                package, dummy=True, show_reload_progress=settings["show_reload_progress"])
+
         if settings["capture_console"]:
             stdout = sys.stdout
             stderr = sys.stderr


### PR DESCRIPTION
`reload_package_on_testing` only had effect when testing the current
package. But it is also very useful to reload before testing the
current file etc.