### PR TITLE
Allow starting coverage after reload

### DIFF
--- a/unittesting.json
+++ b/unittesting.json
@@ -6,6 +6,7 @@
     "verbosity": 2,
     "capture_console": false,
     "reload_package_on_testing": true,
+    "start_coverage_after_reload": false,
     "show_reload_progress": true,
     "output": null
 }

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -75,6 +75,7 @@ class UnitTestingMixin(object):
         deferred = False
         verbosity = 2
         reload_package_on_testing = True
+        start_coverage_after_reload = False
         show_reload_progress = True
         pattern = kargs["pattern"] if "pattern" in kargs else None
         output = kargs["output"] if "output" in kargs else None
@@ -89,6 +90,8 @@ class UnitTestingMixin(object):
             verbosity = ss.get("verbosity", verbosity)
             reload_package_on_testing = ss.get(
                 "reload_package_on_testing", reload_package_on_testing)
+            start_coverage_after_reload = ss.get(
+                "start_coverage_after_reload", start_coverage_after_reload)
             show_reload_progress = ss.get("show_reload_progress", show_reload_progress)
             capture_console = ss.get("capture_console", False)
             if pattern is None:
@@ -105,6 +108,7 @@ class UnitTestingMixin(object):
             "deferred": deferred,
             "verbosity": verbosity,
             "reload_package_on_testing": reload_package_on_testing,
+            "start_coverage_after_reload": start_coverage_after_reload,
             "show_reload_progress": show_reload_progress,
             "pattern": pattern,
             "output": output,

--- a/unittesting/test_coverage.py
+++ b/unittesting/test_coverage.py
@@ -36,9 +36,12 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
 
         cov = coverage.Coverage(
             data_file=data_file, config_file=config_file, include=include, omit=omit)
-        cov.start()
+        if not settings['start_coverage_after_reload']:
+            cov.start()
         if settings["reload_package_on_testing"]:
             self.reload_package(package, dummy=False, show_reload_progress=False)
+        if settings['start_coverage_after_reload']:
+            cov.start()
 
         def cleanup():
             stream.write("\n")


### PR DESCRIPTION
Adds a setting `start_coverage_after_reload` (Default: False)
which tells when `cov.start()` will be called.

`True` usually gets you a 😢 face 🤷‍♂️ 