### PR TITLE
Optionally generate html report

### DIFF
--- a/unittesting.json
+++ b/unittesting.json
@@ -7,5 +7,6 @@
     "capture_console": false,
     "reload_package_on_testing": true,
     "show_reload_progress": true,
-    "output": null
+    "output": null,
+    "generate_html_report": false
 }

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -79,6 +79,7 @@ class UnitTestingMixin(object):
         pattern = kargs["pattern"] if "pattern" in kargs else None
         output = kargs["output"] if "output" in kargs else None
         capture_console = False
+        generate_html_report = False
 
         jfile = os.path.join(sublime.packages_path(), package, "unittesting.json")
         if os.path.exists(jfile):
@@ -91,6 +92,7 @@ class UnitTestingMixin(object):
                 "reload_package_on_testing", reload_package_on_testing)
             show_reload_progress = ss.get("show_reload_progress", show_reload_progress)
             capture_console = ss.get("capture_console", False)
+            generate_html_report = ss.get("generate_html_report", generate_html_report)
             if pattern is None:
                 pattern = ss.get("pattern")
             if not output:
@@ -108,7 +110,8 @@ class UnitTestingMixin(object):
             "show_reload_progress": show_reload_progress,
             "pattern": pattern,
             "output": output,
-            "capture_console": capture_console
+            "capture_console": capture_console,
+            "generate_html_report": generate_html_report
         }
 
     def default_output(self, package):

--- a/unittesting/test_coverage.py
+++ b/unittesting/test_coverage.py
@@ -47,6 +47,9 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
             ignore_errors = cov.get_option("report:ignore_errors")
             show_missing = cov.get_option("report:show_missing")
             cov.report(file=stream, ignore_errors=ignore_errors, show_missing=show_missing)
+            if settings['generate_html_report']:
+                html_output_dir = os.path.join(package_path, 'htmlcov')
+                cov.html_report(directory=html_output_dir, ignore_errors=ignore_errors)
             cov.save()
 
         super().unit_testing(stream, package, settings, [cleanup])


### PR DESCRIPTION
Add option 'generate_html_report' (Default: False). If set to
True will generate the typical html report in the root dir
of the package.
