### PR TITLE
 Pass down command args to build settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
             brew update;
             brew install python || brew upgrade python;
       fi
-    - pip3 install flake8;
+    - pip3 install flake8==3.5;
     - pip3 install flake8-docstrings;
     - sh sbin/travis.sh bootstrap
     - sh sbin/travis.sh install_color_scheme_unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ before_install:
       fi
 
 install:
-    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-            brew update;
-            brew install python || brew upgrade python;
-      fi
     - pip3 install flake8==3.5;
     - pip3 install flake8-docstrings;
     - sh sbin/travis.sh bootstrap

--- a/tests/test_3141596.py
+++ b/tests/test_3141596.py
@@ -67,8 +67,13 @@ def prepare_package(package, output=None, syntax_test=False, syntax_compatibilit
                 sublime.run_command(
                     "unit_testing_color_scheme", {"package": package, "output": outfile})
             else:
-                sublime.run_command(
-                    "unit_testing", {"package": package, "output": outfile})
+                args = {"package": package}
+                if outfile:
+                    # Command args have the highest precedence. Passing down
+                    # 'None' is not what we want, the intention is to omit it
+                    # so that the value from 'unittesting.json' wins.
+                    args["output"] = outfile
+                sublime.run_command("unit_testing", args)
 
             if delay:
                 yield delay

--- a/unittesting/test_color_scheme.py
+++ b/unittesting/test_color_scheme.py
@@ -6,12 +6,12 @@ from .const import DONE_MESSAGE
 
 class UnitTestingColorSchemeCommand(ApplicationCommand, UnitTestingMixin):
 
-    def run(self, package=None, **kargs):
+    def run(self, package=None, **kwargs):
         if not package:
             return
 
         window = sublime.active_window()
-        settings = self.load_unittesting_settings(package, **kargs)
+        settings = self.load_unittesting_settings(package, kwargs)
         stream = self.load_stream(package, settings)
 
         try:

--- a/unittesting/test_current.py
+++ b/unittesting/test_current.py
@@ -5,14 +5,14 @@ from .test_coverage import UnitTestingCoverageCommand
 
 
 class UnitTestingCurrentPackageCommand(UnitTestingCommand):
-    def run(self):
+    def run(self, **kwargs):
         project_name = self.current_package_name
         if not project_name:
             sublime.message_dialog("Cannot determine package name.")
             return
 
         sublime.set_timeout_async(
-            lambda: super(UnitTestingCurrentPackageCommand, self).run(project_name))
+            lambda: super(UnitTestingCurrentPackageCommand, self).run(project_name, **kwargs))
 
     def unit_testing(self, stream, package, settings):
         parent = super(UnitTestingCurrentPackageCommand, self)
@@ -24,20 +24,20 @@ class UnitTestingCurrentPackageCommand(UnitTestingCommand):
 
 class UnitTestingCurrentPackageCoverageCommand(UnitTestingCoverageCommand):
 
-    def run(self):
+    def run(self, **kwargs):
         project_name = self.current_package_name
         if not project_name:
             sublime.message_dialog("Cannot determine package name.")
             return
 
-        super(UnitTestingCurrentPackageCoverageCommand, self).run(project_name)
+        super(UnitTestingCurrentPackageCoverageCommand, self).run(project_name, **kwargs)
 
     def is_enabled(self):
         return "coverage" in sys.modules
 
 
 class UnitTestingCurrentFileCommand(UnitTestingCommand):
-    def run(self):
+    def run(self, **kwargs):
         project_name = self.current_package_name
         if not project_name:
             sublime.message_dialog("Cannot determine package name.")
@@ -49,7 +49,10 @@ class UnitTestingCurrentFileCommand(UnitTestingCommand):
 
         sublime.set_timeout_async(
             lambda: super(UnitTestingCurrentFileCommand, self).run(
-                "{}:{}".format(project_name, test_file)))
+                "{}:{}".format(project_name, test_file),
+                **kwargs
+            )
+        )
 
     def unit_testing(self, stream, package, settings):
         # ideally, we should reuse same function in UnitTestingCurrentPackageCommand

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -13,13 +13,18 @@ import threading
 
 class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
 
-    def run(self, package=None, **kargs):
+    def run(self, package=None, **kwargs):
         if not package:
-            self.prompt_package(lambda x: self.run(x, **kargs))
+            self.prompt_package(lambda x: self.run(x, **kwargs))
             return
 
         package, pattern = self.input_parser(package)
-        settings = self.load_unittesting_settings(package, pattern=pattern, **kargs)
+        if pattern is not None:
+            # kwargs have the highest precedence when evaluating the settings,
+            # so we sure don't want to pass `None` down
+            kwargs['pattern'] = pattern
+
+        settings = self.load_unittesting_settings(package, kwargs)
         stream = self.load_stream(package, settings)
 
         if settings["async"]:

--- a/unittesting/test_syntax.py
+++ b/unittesting/test_syntax.py
@@ -8,10 +8,10 @@ import sublime_api
 
 class UnitTestingSyntaxBase(sublime_plugin.ApplicationCommand, UnitTestingMixin):
 
-    def run(self, package=None, **kargs):
+    def run(self, package=None, **kwargs):
         if not package:
             return
-        settings = self.load_unittesting_settings(package, **kargs)
+        settings = self.load_unittesting_settings(package, kwargs)
         stream = self.load_stream(package, settings)
         self.syntax_testing(stream, package)
 


### PR DESCRIPTION
The rationale here is that (dynamic) args to a command should overrule
the settings in `unittesting.json`. The latter config file is basically
static for the CI whereby the user can build the html report or change
the 'pattern' just via different commands.

E.g. you could define a command like so 

```
  {
      "caption": "UnitTesting: Test Current Package with Coverage (HTML)",
      "command": "unit_testing_current_package_coverage",
      "args": {
          "generate_html_report": true,
      }
  },
```