### PR TITLE
Use view.close() to close view.

### DIFF
--- a/unittesting/helpers/view_test_case.py
+++ b/unittesting/helpers/view_test_case.py
@@ -15,8 +15,7 @@ class ViewTestCase(TestCase):
     def tearDown(self):
         if self.view:
             self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")
+            self.view.close()
 
     def _viewContents(self):
         return self.view.substr(sublime.Region(0, self.view.size()))


### PR DESCRIPTION
`view.close()` [is undocumented](https://github.com/SublimeTextIssues/Core/issues/2290), but it's a much cleaner solution.