### PR TITLE
Deterministic timing for DeferrableTestCase

### DIFF
--- a/tests/test_await_worker.py
+++ b/tests/test_await_worker.py
@@ -1,0 +1,47 @@
+from functools import partial
+import time
+
+import sublime
+
+from unittesting import DeferrableTestCase, AWAIT_WORKER
+
+
+def run_in_worker(fn, *args, **kwargs):
+    sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+
+class TestAwaitingWorkerInDeferredTestCase(DeferrableTestCase):
+
+    def test_ensure_plain_yield_is_faster_than_the_worker_thread(self):
+        messages = []
+
+        def work(message, worktime=None):
+            # simulate that a task might take some time
+            # this will not yield back but block
+            if worktime:
+                time.sleep(worktime)
+
+            messages.append(message)
+
+        run_in_worker(work, 1, 5)
+
+        yield
+
+        self.assertEqual(messages, [])
+
+    def test_await_worker(self):
+        messages = []
+
+        def work(message, worktime=None):
+            # simulate that a task might take some time
+            # this will not yield back but block
+            if worktime:
+                time.sleep(worktime)
+
+            messages.append(message)
+
+        run_in_worker(work, 1, 0.5)
+
+        yield AWAIT_WORKER
+
+        self.assertEqual(messages, [1])

--- a/tests/test_deferred_timing.py
+++ b/tests/test_deferred_timing.py
@@ -1,0 +1,61 @@
+from functools import partial
+import time
+
+import sublime
+
+from unittesting import DeferrableTestCase
+
+
+def run_in_worker(fn, *args, **kwargs):
+    sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+
+class TestTimingInDeferredTestCase(DeferrableTestCase):
+
+    def test_a(self):
+        messages = []
+
+        def work(message, worktime=None):
+            messages.append(message)
+            # simulate that a task might take some time
+            # this will not yield back but block
+            if worktime:
+                time.sleep(worktime)
+
+        def uut():
+            run_in_worker(work, 1, 0.5)   # add task (A)
+            run_in_worker(work, 2)        # add task (B)
+
+
+        uut()   # after that task queue has: (A)..(B)
+        yield   # add task (C) and wait for (C)
+        expected = [1, 2]
+        self.assertEqual(messages, expected)
+
+    def test_b(self):
+        messages = []
+
+        def work(message, worktime=None):
+            messages.append(message)
+            if worktime:
+                time.sleep(worktime)
+
+        def sub_task():
+            run_in_worker(work, 2, 0.5)  # add task (D)
+
+        def uut():
+            run_in_worker(work, 1, 0.5)  # add task (A)
+            run_in_worker(sub_task)      # add task (B)
+
+        uut()
+        # task queue now: (A)..(B)
+
+        yield  # add task (C) and wait for (C)
+               # (A) runs, (B) runs and adds task (D), (C) resolves
+        expected = [1]
+        self.assertEqual(messages, expected)
+        # task queue now: (D)
+        yield  # add task (E) and wait for it
+               # (D) runs and (E) resolves
+        expected = [1, 2]
+        self.assertEqual(messages, expected)

--- a/tests/test_deferred_timing.py
+++ b/tests/test_deferred_timing.py
@@ -1,5 +1,6 @@
 from functools import partial
 import time
+from unittest.mock import patch
 
 import sublime
 
@@ -10,51 +11,71 @@ def run_in_worker(fn, *args, **kwargs):
     sublime.set_timeout_async(partial(fn, *args, **kwargs))
 
 
+# When we swap `set_timeout_async` with `set_timeout` we basically run
+# our program single-threaded.
+# This has some benefits:
+# - We avoid async/timing issues
+# - We can use plain `yield` to run Sublime's task queue empty, see below
+# - Every code we run will get correct coverage
+#
+# However note, that Sublime will just put all async events on the queue,
+# avoiding the API. We cannot patch that. That means, the event handlers
+# will *not* run using plain `yield` like below, you still have to await
+# them using `yield AWAIT_WORKER`.
+#
+
 class TestTimingInDeferredTestCase(DeferrableTestCase):
 
     def test_a(self):
-        messages = []
+        # `patch` doesn't work as a decorator with generator functions so we
+        # use `with`
+        with patch.object(sublime, 'set_timeout_async', sublime.set_timeout):
+            messages = []
 
-        def work(message, worktime=None):
-            messages.append(message)
-            # simulate that a task might take some time
-            # this will not yield back but block
-            if worktime:
-                time.sleep(worktime)
+            def work(message, worktime=None):
+                # simulate that a task might take some time
+                # this will not yield back but block
+                if worktime:
+                    time.sleep(worktime)
 
-        def uut():
-            run_in_worker(work, 1, 0.5)   # add task (A)
-            run_in_worker(work, 2)        # add task (B)
+                messages.append(message)
 
-        uut()   # after that task queue has: (A)..(B)
-        yield   # add task (C) and wait for (C)
-        expected = [1, 2]
-        self.assertEqual(messages, expected)
+            def uut():
+                run_in_worker(work, 1, 0.5)   # add task (A)
+                run_in_worker(work, 2)        # add task (B)
+
+            uut()   # after that task queue has: (A)..(B)
+            yield   # add task (C) and wait for (C)
+            expected = [1, 2]
+            self.assertEqual(messages, expected)
 
     def test_b(self):
-        messages = []
+        # `patch` doesn't work as a decorator with generator functions so we
+        # use `with`
+        with patch.object(sublime, 'set_timeout_async', sublime.set_timeout):
+            messages = []
 
-        def work(message, worktime=None):
-            messages.append(message)
-            if worktime:
-                time.sleep(worktime)
+            def work(message, worktime=None):
+                if worktime:
+                    time.sleep(worktime)
+                messages.append(message)
 
-        def sub_task():
-            run_in_worker(work, 2, 0.5)  # add task (D)
+            def sub_task():
+                run_in_worker(work, 2, 0.5)  # add task (D)
 
-        def uut():
-            run_in_worker(work, 1, 0.5)  # add task (A)
-            run_in_worker(sub_task)      # add task (B)
+            def uut():
+                run_in_worker(work, 1, 0.3)    # add task (A)
+                run_in_worker(sub_task)      # add task (B)
 
-        uut()
-        # task queue now: (A)..(B)
+            uut()
+            # task queue now: (A)..(B)
 
-        yield  # add task (C) and wait for (C)
-        #        (A) runs, (B) runs and adds task (D), (C) resolves
-        expected = [1]
-        self.assertEqual(messages, expected)
-        # task queue now: (D)
-        yield  # add task (E) and wait for it
-        #        (D) runs and (E) resolves
-        expected = [1, 2]
-        self.assertEqual(messages, expected)
+            yield  # add task (C) and wait for (C)
+            #        (A) runs, (B) runs and adds task (D), (C) resolves
+            expected = [1]
+            self.assertEqual(messages, expected)
+            # task queue now: (D)
+            yield  # add task (E) and wait for it
+            #        (D) runs and (E) resolves
+            expected = [1, 2]
+            self.assertEqual(messages, expected)

--- a/tests/test_deferred_timing.py
+++ b/tests/test_deferred_timing.py
@@ -26,7 +26,6 @@ class TestTimingInDeferredTestCase(DeferrableTestCase):
             run_in_worker(work, 1, 0.5)   # add task (A)
             run_in_worker(work, 2)        # add task (B)
 
-
         uut()   # after that task queue has: (A)..(B)
         yield   # add task (C) and wait for (C)
         expected = [1, 2]
@@ -51,11 +50,11 @@ class TestTimingInDeferredTestCase(DeferrableTestCase):
         # task queue now: (A)..(B)
 
         yield  # add task (C) and wait for (C)
-               # (A) runs, (B) runs and adds task (D), (C) resolves
+        #        (A) runs, (B) runs and adds task (D), (C) resolves
         expected = [1]
         self.assertEqual(messages, expected)
         # task queue now: (D)
         yield  # add task (E) and wait for it
-               # (D) runs and (E) resolves
+        #        (D) runs and (E) resolves
         expected = [1, 2]
         self.assertEqual(messages, expected)

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,4 +1,4 @@
-from .core import DeferrableTestCase
+from .core import DeferrableTestCase, AWAIT_WORKER
 from .scheduler import UnitTestingRunSchedulerCommand
 from .scheduler import run_scheduler
 from .test_package import UnitTestingCommand
@@ -22,5 +22,6 @@ __all__ = [
     "UnitTestingCurrentPackageCoverageCommand",
     "UnitTestingSyntaxCommand",
     "UnitTestingSyntaxCompatibilityCommand",
-    "UnitTestingColorSchemeCommand"
+    "UnitTestingColorSchemeCommand",
+    "AWAIT_WORKER"
 ]

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,6 +1,12 @@
-from .st3.runner import DeferringTextTestRunner
+from .st3.runner import DeferringTextTestRunner, AWAIT_WORKER
 from .st3.case import DeferrableTestCase
 from .st3.suite import DeferrableTestSuite
 from .loader import UnitTestingLoader as TestLoader
 
-__all__ = ["TestLoader", "DeferringTextTestRunner", "DeferrableTestCase", "DeferrableTestSuite"]
+__all__ = [
+    "TestLoader",
+    "DeferringTextTestRunner",
+    "DeferrableTestCase",
+    "DeferrableTestSuite",
+    "AWAIT_WORKER"
+]

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -5,7 +5,7 @@ import sublime
 
 
 def defer(delay, callback, *args, **kwargs):
-    sublime.set_timeout(lambda: callback(*args, **kwargs), delay)
+    sublime.set_timeout_async(lambda: callback(*args, **kwargs), delay)
 
 
 class DeferringTextTestRunner(TextTestRunner):
@@ -40,7 +40,7 @@ class DeferringTextTestRunner(TextTestRunner):
                     startTestRun()
                 try:
                     deferred = test(result)
-                    defer(10, _continue_testing, deferred)
+                    _continue_testing(deferred)
 
                 except Exception as e:
                     _handle_error(e)
@@ -57,7 +57,7 @@ class DeferringTextTestRunner(TextTestRunner):
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
                 else:
-                    defer(10, _continue_testing, deferred)
+                    defer(0, _continue_testing, deferred)
 
             except StopIteration:
                 _stop_testing()
@@ -132,4 +132,4 @@ class DeferringTextTestRunner(TextTestRunner):
             else:
                 self.stream.write("\n")
 
-        sublime.set_timeout(_start_testing, 10)
+        _start_testing()

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -1,3 +1,4 @@
+from functools import partial
 import time
 from unittest.runner import TextTestRunner, registerResult
 import warnings
@@ -5,11 +6,15 @@ import sublime
 
 
 def defer(delay, callback, *args, **kwargs):
-    sublime.set_timeout_async(lambda: callback(*args, **kwargs), delay)
+    sublime.set_timeout_async(partial(callback, *args, **kwargs), delay)
 
 
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
+
+    # How can this be user configurable?
+    # controlled_timing = False
+    controlled_timing = True
 
     def run(self, test):
         """Run the given test case or test suite."""

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -24,8 +24,12 @@ class DeferringTextTestRunner(TextTestRunner):
         result.failfast = self.failfast
         result.buffer = self.buffer
         startTime = time.time()
+        original_set_timeout_async = sublime.set_timeout_async
 
         def _start_testing():
+            if self.controlled_timing:
+                sublime.set_timeout_async = sublime.set_timeout
+
             with warnings.catch_warnings():
                 if self.warnings:
                     # if self.warnings is set, use it to filter all the warnings
@@ -91,6 +95,9 @@ class DeferringTextTestRunner(TextTestRunner):
             raise e
 
         def _stop_testing():
+            if self.controlled_timing:
+                sublime.set_timeout_async = original_set_timeout_async
+
             with warnings.catch_warnings():
                 stopTestRun = getattr(result, 'stopTestRun', None)
                 if stopTestRun is not None:

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -6,7 +6,8 @@ import sublime
 
 
 def defer(delay, callback, *args, **kwargs):
-    sublime.set_timeout_async(partial(callback, *args, **kwargs), delay)
+    sublime.set_timeout(partial(callback, *args, **kwargs), delay)
+
 
 
 class DeferringTextTestRunner(TextTestRunner):

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -49,10 +49,10 @@ class DeferringTextTestRunner(TextTestRunner):
             try:
                 condition = next(deferred)
                 if callable(condition):
-                    defer(100, _wait_condition, deferred, condition)
+                    defer(0, _wait_condition, deferred, condition)
                 elif isinstance(condition, dict) and "condition" in condition and \
                         callable(condition["condition"]):
-                    period = condition.get("period", 100)
+                    period = condition.get("period", 5)
                     defer(period, _wait_condition, deferred, **condition)
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
@@ -66,15 +66,15 @@ class DeferringTextTestRunner(TextTestRunner):
             except Exception as e:
                 _handle_error(e)
 
-        def _wait_condition(deferred, condition, period=100, timeout=10000, start_time=None):
+        def _wait_condition(deferred, condition, period=5, timeout=10000, start_time=None):
             if start_time is None:
                 start_time = time.time()
 
             if condition():
-                defer(10, _continue_testing, deferred)
+                _continue_testing(deferred)
             elif (time.time() - start_time) * 1000 >= timeout:
                 self.stream.writeln("Condition timeout, continue anyway.")
-                defer(10, _continue_testing, deferred)
+                _continue_testing(deferred)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -12,10 +12,6 @@ def defer(delay, callback, *args, **kwargs):
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
 
-    # How can this be user configurable?
-    # controlled_timing = False
-    controlled_timing = True
-
     def run(self, test):
         """Run the given test case or test suite."""
         self.finished = False
@@ -24,12 +20,8 @@ class DeferringTextTestRunner(TextTestRunner):
         result.failfast = self.failfast
         result.buffer = self.buffer
         startTime = time.time()
-        original_set_timeout_async = sublime.set_timeout_async
 
         def _start_testing():
-            if self.controlled_timing:
-                sublime.set_timeout_async = sublime.set_timeout
-
             with warnings.catch_warnings():
                 if self.warnings:
                     # if self.warnings is set, use it to filter all the warnings
@@ -95,9 +87,6 @@ class DeferringTextTestRunner(TextTestRunner):
             raise e
 
         def _stop_testing():
-            if self.controlled_timing:
-                sublime.set_timeout_async = original_set_timeout_async
-
             with warnings.catch_warnings():
                 stopTestRun = getattr(result, 'stopTestRun', None)
                 if stopTestRun is not None:

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -6,8 +6,14 @@ import sublime
 
 
 def defer(delay, callback, *args, **kwargs):
+    # Rely on late binding in case a user patches it
     sublime.set_timeout(partial(callback, *args, **kwargs), delay)
 
+
+AWAIT_WORKER = 'AWAIT_WORKER'
+# Extract `set_timeout_async`, t.i. *avoid* late binding, in case a user
+# patches it
+run_on_worker = sublime.set_timeout_async
 
 
 class DeferringTextTestRunner(TextTestRunner):
@@ -58,6 +64,10 @@ class DeferringTextTestRunner(TextTestRunner):
                     defer(period, _wait_condition, deferred, **condition)
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
+                elif condition == AWAIT_WORKER:
+                    run_on_worker(
+                        partial(defer, 0, _continue_testing, deferred)
+                    )
                 else:
                     defer(0, _continue_testing, deferred)
 


### PR DESCRIPTION
Sublime's worker thread is a task queue. If you put
tasks on it, they will run *ordered*.

We can use this to make the `yield` timing deterministic.
If we just `yield` (without an argument) we enqueue a task
to be run ASAP. That means it will wait for tasks in the
queue and then yield back to the test code.

E.g. from the test we invoke the unit-under-test which in turn
puts task (A) and (B) on the worker. We then `yield` which puts
itself as (C) on the queue and waits for it. Sublime will now run
(A), (B), and finally (C) ordered. The test runner now yields
control back to the test.

If (A) in turn enqueued a task (D) on the queue, it will not have
run yet, and in fact will not run at all if we not `yield` again.

See the test included here.

Using this, I could bring down the execution time of the
test in https://github.com/divmain/GitSavvy/pull/1056 from ~7.7s
to 2.7s. I could replace all `yield <condition>` expressions with
single or double `yield`s, making the test more reasonable. Bc
I know that a command e.g. 'hops' two times, I know exactly that
I have to `yield` two times.

This comes with the big caveat that coverage doesn't work on the
worker thread. This is already true right now, see
https://github.com/divmain/GitSavvy/pull/1056#issuecomment-442384812
and a big annoyance for writing functional tests. E.g. as soon
as we just issue a command which itself is implemented to run
'async' (t.i. on the worker thread) and then just `yield <condition>`
to wait for it, the code under test will not be marked as 'covered'.