### PR TITLE
Better yield condition

### DIFF
--- a/tests/_Deferred/tests/test.py
+++ b/tests/_Deferred/tests/test.py
@@ -46,16 +46,3 @@ class TestDeferrable(DeferrableTestCase):
         yield condition
 
         self.assertEqual(x[0], 1)
-
-    def test_condition_timeout(self):
-        x = []
-
-        def append():
-            x.append(1)
-
-        sublime.set_timeout(append, 100)
-
-        # wait until condition timeout
-        yield {"condition": lambda: False, "timeout": 500}
-
-        self.assertEqual(x[0], 1)

--- a/tests/test_yield_condition.py
+++ b/tests/test_yield_condition.py
@@ -15,3 +15,16 @@ class TestYieldConditionsHandlingInDeferredTestCase(DeferrableTestCase):
         rv = yield lambda: 'Hans Peter'
 
         self.assertEqual(rv, 'Hans Peter')
+
+    def test_handle_condition_timeout_as_failure(self):
+        try:
+            yield {
+                'condition': lambda: True is False,
+                'timeout': 100
+            }
+            self.fail('Unmet condition should have thrown')
+        except TimeoutError as e:
+            self.assertEqual(
+                str(e),
+                'Condition not fulfilled within 0.10 seconds'
+            )

--- a/tests/test_yield_condition.py
+++ b/tests/test_yield_condition.py
@@ -1,0 +1,17 @@
+from unittesting import DeferrableTestCase
+
+
+class TestYieldConditionsHandlingInDeferredTestCase(DeferrableTestCase):
+    def test_reraises_errors_raised_in_conditions(self):
+        try:
+            yield lambda: 1 / 0
+            self.fail('Did not reraise the exception from the condition')
+        except ZeroDivisionError:
+            pass
+        except Exception:
+            self.fail('Did not throw the original exception')
+
+    def test_returns_condition_value(self):
+        rv = yield lambda: 'Hans Peter'
+
+        self.assertEqual(rv, 'Hans Peter')

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -83,8 +83,11 @@ class DeferringTextTestRunner(TextTestRunner):
             if send_value:
                 defer(10, _continue_testing, deferred, send_value=send_value)
             elif (time.time() - start_time) * 1000 >= timeout:
-                self.stream.writeln("Condition timeout, continue anyway.")
-                defer(10, _continue_testing, deferred)
+                error = TimeoutError(
+                    'Condition not fulfilled within {:.2f} seconds'
+                    .format(timeout / 1000)
+                )
+                defer(10, _continue_testing, deferred, throw_value=error)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 


### PR DESCRIPTION
1. Currently, a `yield <conditon>` where the condition itself throws leaves the test in an undefined state. 

E.g. `yield panel.find(...)` when panel is None

This PR reraises the error inside the generator (`gen.throw()`).

2. It is also useful and cheap to implement to get the last value back in the test. This is implemented using `gen.send()` instead of just `next(gen)`

```
        region = yield from lambda: panel.find(COMMIT_1, 0, sublime.LITERAL)
		# assert that region is placed correctly
```

3. From a tester standpoint a condition that times out must throw, currently it 'continues anyway'. 

E.g. in the GitSavvy tests I often have to do 

```
        yield from lambda: panel.find(COMMIT_1, 0, sublime.LITERAL)

        # `yield condition` will continue after a timeout so we need
        # to actually assert here
        actual = panel.find(COMMIT_1, 0, sublime.LITERAL)
        self.assertTrue(actual)
```
