### PR TITLE
Make `doCleanups` work for the DeferrableTestCase

### DIFF
--- a/tests/test_ensure_do_cleanups.py
+++ b/tests/test_ensure_do_cleanups.py
@@ -1,0 +1,15 @@
+from unittesting import DeferrableTestCase
+
+
+class TestDoCleanups(DeferrableTestCase):
+
+    def test_ensure_do_cleanups_works(self):
+        messages = []
+
+        def work(message):
+            messages.append(message)
+
+        self.addCleanup(work, 1)
+        yield from self.doCleanups()
+
+        self.assertEqual(messages, [1])

--- a/tests/test_ensure_do_cleanups.py
+++ b/tests/test_ensure_do_cleanups.py
@@ -1,9 +1,9 @@
 from unittesting import DeferrableTestCase
 
 
-class TestDoCleanups(DeferrableTestCase):
+class TestExplicitDoCleanups(DeferrableTestCase):
 
-    def test_ensure_do_cleanups_works(self):
+    def test_manually_calling_do_cleanups_works(self):
         messages = []
 
         def work(message):
@@ -13,3 +13,14 @@ class TestDoCleanups(DeferrableTestCase):
         yield from self.doCleanups()
 
         self.assertEqual(messages, [1])
+
+
+cleanup_called = []
+
+
+class TestImplicitDoCleanupsOnTeardown(DeferrableTestCase):
+    def test_a_prepare(self):
+        self.addCleanup(lambda: cleanup_called.append(1))
+
+    def test_b_assert(self):
+        self.assertEqual(cleanup_called, [1])

--- a/unittesting/core/st3/case.py
+++ b/unittesting/core/st3/case.py
@@ -63,16 +63,10 @@ class DeferrableTestCase(unittest.TestCase):
             outcome = _Outcome()
             self._outcomeForDoCleanups = outcome
 
-            deferred = self._executeTestPart(self.setUp, outcome)
-            if isiterable(deferred):
-                yield from deferred
+            yield from self._executeTestPart(self.setUp, outcome)
             if outcome.success:
-                deferred = self._executeTestPart(testMethod, outcome, isTest=True)
-                if isiterable(deferred):
-                    yield from deferred
-                deferred = self._executeTestPart(self.tearDown, outcome)
-                if isiterable(deferred):
-                    yield from deferred
+                yield from self._executeTestPart(testMethod, outcome, isTest=True)
+                yield from self._executeTestPart(self.tearDown, outcome)
 
             yield from self.doCleanups()
             if outcome.success:


### PR DESCRIPTION
The `addCleanup`/`doCleanups` is actually the recommended way to manage fixtures within pythons's unitest framework. This did not work for the DeferrableTestCase bc `_executeTestPart` is a generator not a simple functions and just calling it is therefore not enough to execute it.

This should have the nice side effect that we can also yield waiting time from such cleanup functions.