### PR TITLE
UX: Remember last current file and use it

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,6 @@ max-line-length = 120
 # D103  Missing docstring in public function
 # D104  Missing docstring in public package
 # D107  Missing docstring in __init__
+# W503  line break before binary operator
 # W606  'async' and 'await' are reserved keywords starting with Python 3.7
-ignore = D100, D101, D102, D103, D104, D107, W606
+ignore = D100, D101, D102, D103, D104, D107, W503, W606

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -62,13 +62,6 @@ class UnitTestingMixin(object):
 
         return None
 
-    @property
-    def current_test_file(self):
-        current_file = sublime.active_window().active_view().file_name()
-        if current_file and current_file.endswith(".py"):
-            current_file = os.path.basename(current_file)
-        return current_file
-
     def input_parser(self, package):
         m = re.match(r'([^:]+):(.+)', package)
         if m:

--- a/unittesting/test_current.py
+++ b/unittesting/test_current.py
@@ -56,9 +56,12 @@ class UnitTestingCurrentFileCommand(UnitTestingCommand):
         file_name = os.path.basename(current_file)
         if file_name and fnmatch(file_name, settings['pattern']):
             test_file = file_name
-            window.settings().set('last_test_file', test_file)
+            window.settings().set('UnitTesting.last_test_file', test_file)
         else:
-            test_file = window.settings().get('last_test_file') or current_file
+            test_file = (
+                window.settings().get('UnitTesting.last_test_file')
+                or current_file
+            )
 
         sublime.set_timeout_async(
             lambda: super(UnitTestingCurrentFileCommand, self).run(


### PR DESCRIPTION
If a user switches from test file to implementation file, it
is useful that 'Test Current File' remembers and executes the
actual last test file it ran.

Changes:

- We actually match the filename against `settings['pattern']`.
  Not all files with a '.py' suffix are test files.

- We store the last used test file in the `window.settings()`
  which is cheap to implement and probably the right thing.

- Remove `current_test_file` property which was a misnomer and 
  is now unused anyway.