### PR TITLE
Next

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,6 @@ max-line-length = 120
 # D103  Missing docstring in public function
 # D104  Missing docstring in public package
 # D107  Missing docstring in __init__
+# W503  line break before binary operator
 # W606  'async' and 'await' are reserved keywords starting with Python 3.7
-ignore = D100, D101, D102, D103, D104, D107, W606
+ignore = D100, D101, D102, D103, D104, D107, W503, W606

--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@ UnitTesting
 
 This is a unittest framework for Sublime Text 3. It runs unittest testcases on local machines and CI services such as Travis CI, Circle CI and AppVeyor. It also supports testing syntax_test files for the new [sublime-syntax](https://www.sublimetext.com/docs/3/syntax.html) format.
 
-
-**News**: UnitTesting is now housed by `SublimeText`. You may want to change the urls from
-`randy3k/UnitTesting` to `SublimeText/UnitTesting`, e.g.:
-
-- https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
-
-
 ## Preparation
 
 1. Before testing anything, you have to install [UnitTesting](https://github.com/SublimeText/UnitTesting) via Package Control.

--- a/tests/test_3141596.py
+++ b/tests/test_3141596.py
@@ -38,7 +38,7 @@ def cleanup_package(package):
 
 
 def prepare_package(package, output=None, syntax_test=False, syntax_compatibility=False,
-                    color_scheme_test=False, delay=None):
+                    color_scheme_test=False, delay=100):
     def wrapper(func):
         @wraps(func)
         def real_wrapper(self):

--- a/tests/test_await_worker.py
+++ b/tests/test_await_worker.py
@@ -1,0 +1,47 @@
+from functools import partial
+import time
+
+import sublime
+
+from unittesting import DeferrableTestCase, AWAIT_WORKER
+
+
+def run_in_worker(fn, *args, **kwargs):
+    sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+
+class TestAwaitingWorkerInDeferredTestCase(DeferrableTestCase):
+
+    def test_ensure_plain_yield_is_faster_than_the_worker_thread(self):
+        messages = []
+
+        def work(message, worktime=None):
+            # simulate that a task might take some time
+            # this will not yield back but block
+            if worktime:
+                time.sleep(worktime)
+
+            messages.append(message)
+
+        run_in_worker(work, 1, 5)
+
+        yield
+
+        self.assertEqual(messages, [])
+
+    def test_await_worker(self):
+        messages = []
+
+        def work(message, worktime=None):
+            # simulate that a task might take some time
+            # this will not yield back but block
+            if worktime:
+                time.sleep(worktime)
+
+            messages.append(message)
+
+        run_in_worker(work, 1, 0.5)
+
+        yield AWAIT_WORKER
+
+        self.assertEqual(messages, [1])

--- a/tests/test_deferred_timing.py
+++ b/tests/test_deferred_timing.py
@@ -1,0 +1,81 @@
+from functools import partial
+import time
+from unittest.mock import patch
+
+import sublime
+
+from unittesting import DeferrableTestCase
+
+
+def run_in_worker(fn, *args, **kwargs):
+    sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+
+# When we swap `set_timeout_async` with `set_timeout` we basically run
+# our program single-threaded.
+# This has some benefits:
+# - We avoid async/timing issues
+# - We can use plain `yield` to run Sublime's task queue empty, see below
+# - Every code we run will get correct coverage
+#
+# However note, that Sublime will just put all async events on the queue,
+# avoiding the API. We cannot patch that. That means, the event handlers
+# will *not* run using plain `yield` like below, you still have to await
+# them using `yield AWAIT_WORKER`.
+#
+
+class TestTimingInDeferredTestCase(DeferrableTestCase):
+
+    def test_a(self):
+        # `patch` doesn't work as a decorator with generator functions so we
+        # use `with`
+        with patch.object(sublime, 'set_timeout_async', sublime.set_timeout):
+            messages = []
+
+            def work(message, worktime=None):
+                # simulate that a task might take some time
+                # this will not yield back but block
+                if worktime:
+                    time.sleep(worktime)
+
+                messages.append(message)
+
+            def uut():
+                run_in_worker(work, 1, 0.5)   # add task (A)
+                run_in_worker(work, 2)        # add task (B)
+
+            uut()   # after that task queue has: (A)..(B)
+            yield   # add task (C) and wait for (C)
+            expected = [1, 2]
+            self.assertEqual(messages, expected)
+
+    def test_b(self):
+        # `patch` doesn't work as a decorator with generator functions so we
+        # use `with`
+        with patch.object(sublime, 'set_timeout_async', sublime.set_timeout):
+            messages = []
+
+            def work(message, worktime=None):
+                if worktime:
+                    time.sleep(worktime)
+                messages.append(message)
+
+            def sub_task():
+                run_in_worker(work, 2, 0.5)  # add task (D)
+
+            def uut():
+                run_in_worker(work, 1, 0.3)    # add task (A)
+                run_in_worker(sub_task)      # add task (B)
+
+            uut()
+            # task queue now: (A)..(B)
+
+            yield  # add task (C) and wait for (C)
+            #        (A) runs, (B) runs and adds task (D), (C) resolves
+            expected = [1]
+            self.assertEqual(messages, expected)
+            # task queue now: (D)
+            yield  # add task (E) and wait for it
+            #        (D) runs and (E) resolves
+            expected = [1, 2]
+            self.assertEqual(messages, expected)

--- a/tests/test_yield_condition.py
+++ b/tests/test_yield_condition.py
@@ -15,3 +15,16 @@ class TestYieldConditionsHandlingInDeferredTestCase(DeferrableTestCase):
         rv = yield lambda: 'Hans Peter'
 
         self.assertEqual(rv, 'Hans Peter')
+
+    def test_handle_condition_timeout_as_failure(self):
+        try:
+            yield {
+                'condition': lambda: True is False,
+                'timeout': 100
+            }
+            self.fail('Unmet condition should have thrown')
+        except TimeoutError as e:
+            self.assertEqual(
+                str(e),
+                'Condition not fulfilled within 0.10 seconds'
+            )

--- a/tests/test_yield_condition.py
+++ b/tests/test_yield_condition.py
@@ -1,0 +1,17 @@
+from unittesting import DeferrableTestCase
+
+
+class TestYieldConditionsHandlingInDeferredTestCase(DeferrableTestCase):
+    def test_reraises_errors_raised_in_conditions(self):
+        try:
+            yield lambda: 1 / 0
+            self.fail('Did not reraise the exception from the condition')
+        except ZeroDivisionError:
+            pass
+        except Exception:
+            self.fail('Did not throw the original exception')
+
+    def test_returns_condition_value(self):
+        rv = yield lambda: 'Hans Peter'
+
+        self.assertEqual(rv, 'Hans Peter')

--- a/unittesting.json
+++ b/unittesting.json
@@ -3,7 +3,7 @@
     "pattern" : "test*.py",
     "async": false,
     "deferred": true,
-    "fast_timings": true,
+    "legacy_runner": false,
     "verbosity": 2,
     "capture_console": false,
     "reload_package_on_testing": true,

--- a/unittesting.json
+++ b/unittesting.json
@@ -3,6 +3,7 @@
     "pattern" : "test*.py",
     "async": false,
     "deferred": true,
+    "fast_timings": true,
     "verbosity": 2,
     "capture_console": false,
     "reload_package_on_testing": true,

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,4 +1,4 @@
-from .core import DeferrableTestCase
+from .core import DeferrableTestCase, AWAIT_WORKER
 from .scheduler import UnitTestingRunSchedulerCommand
 from .scheduler import run_scheduler
 from .test_package import UnitTestingCommand
@@ -22,5 +22,6 @@ __all__ = [
     "UnitTestingCurrentPackageCoverageCommand",
     "UnitTestingSyntaxCommand",
     "UnitTestingSyntaxCompatibilityCommand",
-    "UnitTestingColorSchemeCommand"
+    "UnitTestingColorSchemeCommand",
+    "AWAIT_WORKER"
 ]

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,13 +1,13 @@
 from .st3.runner import DeferringTextTestRunner, AWAIT_WORKER
-from .st3.fast_runner import FastDeferringTextTestRunner
+from .st3.legacy_runner import LegacyDeferringTextTestRunner
 from .st3.case import DeferrableTestCase
 from .st3.suite import DeferrableTestSuite
 from .loader import UnitTestingLoader as TestLoader
 
 __all__ = [
     "TestLoader",
-    "FastDeferringTextTestRunner",
     "DeferringTextTestRunner",
+    "LegacyDeferringTextTestRunner",
     "DeferrableTestCase",
     "DeferrableTestSuite",
     "AWAIT_WORKER"

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,10 +1,12 @@
 from .st3.runner import DeferringTextTestRunner, AWAIT_WORKER
+from .st3.fast_runner import FastDeferringTextTestRunner
 from .st3.case import DeferrableTestCase
 from .st3.suite import DeferrableTestSuite
 from .loader import UnitTestingLoader as TestLoader
 
 __all__ = [
     "TestLoader",
+    "FastDeferringTextTestRunner",
     "DeferringTextTestRunner",
     "DeferrableTestCase",
     "DeferrableTestSuite",

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,6 +1,12 @@
-from .st3.runner import DeferringTextTestRunner
+from .st3.runner import DeferringTextTestRunner, AWAIT_WORKER
 from .st3.case import DeferrableTestCase
 from .st3.suite import DeferrableTestSuite
 from .loader import UnitTestingLoader as TestLoader
 
-__all__ = ["TestLoader", "DeferringTextTestRunner", "DeferrableTestCase", "DeferrableTestSuite"]
+__all__ = [
+    "TestLoader",
+    "DeferringTextTestRunner",
+    "DeferrableTestCase",
+    "DeferrableTestSuite",
+    "AWAIT_WORKER"
+]

--- a/unittesting/core/st3/fast_runner.py
+++ b/unittesting/core/st3/fast_runner.py
@@ -1,0 +1,167 @@
+from functools import partial
+import time
+from unittest.runner import TextTestRunner, registerResult
+import warnings
+import sublime
+
+
+def defer(delay, callback, *args, **kwargs):
+    # Rely on late binding in case a user patches it
+    sublime.set_timeout(partial(callback, *args, **kwargs), delay)
+
+
+DEFAULT_CONDITION_POLL_TIME = 17
+DEFAULT_CONDITION_TIMEOUT = 4000
+AWAIT_WORKER = 'AWAIT_WORKER'
+# Extract `set_timeout_async`, t.i. *avoid* late binding, in case a user
+# patches it
+run_on_worker = sublime.set_timeout_async
+
+
+class FastDeferringTextTestRunner(TextTestRunner):
+    """This test runner runs tests in deferred slices."""
+
+    def run(self, test):
+        """Run the given test case or test suite."""
+        self.finished = False
+        result = self._makeResult()
+        registerResult(result)
+        result.failfast = self.failfast
+        result.buffer = self.buffer
+        startTime = time.time()
+
+        def _start_testing():
+            with warnings.catch_warnings():
+                if self.warnings:
+                    # if self.warnings is set, use it to filter all the warnings
+                    warnings.simplefilter(self.warnings)
+                    # if the filter is 'default' or 'always', special-case the
+                    # warnings from the deprecated unittest methods to show them
+                    # no more than once per module, because they can be fairly
+                    # noisy.  The -Wd and -Wa flags can be used to bypass this
+                    # only when self.warnings is None.
+                    if self.warnings in ['default', 'always']:
+                        warnings.filterwarnings(
+                            'module',
+                            category=DeprecationWarning,
+                            message='Please use assert\\w+ instead.')
+                startTestRun = getattr(result, 'startTestRun', None)
+                if startTestRun is not None:
+                    startTestRun()
+                try:
+                    deferred = test(result)
+                    _continue_testing(deferred)
+
+                except Exception as e:
+                    _handle_error(e)
+
+        def _continue_testing(deferred, send_value=None, throw_value=None):
+            try:
+                if throw_value:
+                    condition = deferred.throw(throw_value)
+                else:
+                    condition = deferred.send(send_value)
+
+                if callable(condition):
+                    defer(0, _wait_condition, deferred, condition)
+                elif isinstance(condition, dict) and "condition" in condition and \
+                        callable(condition["condition"]):
+                    period = condition.get("period", DEFAULT_CONDITION_POLL_TIME)
+                    defer(period, _wait_condition, deferred, **condition)
+                elif isinstance(condition, int):
+                    defer(condition, _continue_testing, deferred)
+                elif condition == AWAIT_WORKER:
+                    run_on_worker(
+                        partial(defer, 0, _continue_testing, deferred)
+                    )
+                else:
+                    defer(0, _continue_testing, deferred)
+
+            except StopIteration:
+                _stop_testing()
+                self.finished = True
+
+            except Exception as e:
+                _handle_error(e)
+
+        def _wait_condition(
+            deferred, condition,
+            period=DEFAULT_CONDITION_POLL_TIME,
+            timeout=DEFAULT_CONDITION_TIMEOUT,
+            start_time=None
+        ):
+            if start_time is None:
+                start_time = time.time()
+
+            try:
+                send_value = condition()
+            except Exception as e:
+                _continue_testing(deferred, throw_value=e)
+                return
+
+            if send_value:
+                _continue_testing(deferred, send_value=send_value)
+            elif (time.time() - start_time) * 1000 >= timeout:
+                error = TimeoutError(
+                    'Condition not fulfilled within {:.2f} seconds'
+                    .format(timeout / 1000)
+                )
+                _continue_testing(deferred, throw_value=error)
+            else:
+                defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
+
+        def _handle_error(e):
+            stopTestRun = getattr(result, 'stopTestRun', None)
+            if stopTestRun is not None:
+                stopTestRun()
+            self.finished = True
+            raise e
+
+        def _stop_testing():
+            with warnings.catch_warnings():
+                stopTestRun = getattr(result, 'stopTestRun', None)
+                if stopTestRun is not None:
+                    stopTestRun()
+
+            stopTime = time.time()
+            timeTaken = stopTime - startTime
+            result.printErrors()
+            if hasattr(result, 'separator2'):
+                self.stream.writeln(result.separator2)
+            run = result.testsRun
+            self.stream.writeln("Ran %d test%s in %.3fs" %
+                                (run, run != 1 and "s" or "", timeTaken))
+            self.stream.writeln()
+
+            expectedFails = unexpectedSuccesses = skipped = 0
+            try:
+                results = map(len, (result.expectedFailures,
+                                    result.unexpectedSuccesses,
+                                    result.skipped))
+            except AttributeError:
+                pass
+            else:
+                expectedFails, unexpectedSuccesses, skipped = results
+
+            infos = []
+            if not result.wasSuccessful():
+                self.stream.write("FAILED")
+                failed, errored = len(result.failures), len(result.errors)
+                if failed:
+                    infos.append("failures=%d" % failed)
+                if errored:
+                    infos.append("errors=%d" % errored)
+            else:
+                self.stream.write("OK")
+            if skipped:
+                infos.append("skipped=%d" % skipped)
+            if expectedFails:
+                infos.append("expected failures=%d" % expectedFails)
+            if unexpectedSuccesses:
+                infos.append("unexpected successes=%d" % unexpectedSuccesses)
+            if infos:
+                self.stream.writeln(" (%s)" % (", ".join(infos),))
+            else:
+                self.stream.write("\n")
+
+        _start_testing()

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -10,8 +10,6 @@ def defer(delay, callback, *args, **kwargs):
     sublime.set_timeout(partial(callback, *args, **kwargs), delay)
 
 
-DEFAULT_CONDITION_POLL_TIME = 17
-DEFAULT_CONDITION_TIMEOUT = 4000
 AWAIT_WORKER = 'AWAIT_WORKER'
 # Extract `set_timeout_async`, t.i. *avoid* late binding, in case a user
 # patches it
@@ -50,7 +48,7 @@ class DeferringTextTestRunner(TextTestRunner):
                     startTestRun()
                 try:
                     deferred = test(result)
-                    _continue_testing(deferred)
+                    defer(10, _continue_testing, deferred)
 
                 except Exception as e:
                     _handle_error(e)
@@ -63,10 +61,10 @@ class DeferringTextTestRunner(TextTestRunner):
                     condition = deferred.send(send_value)
 
                 if callable(condition):
-                    defer(0, _wait_condition, deferred, condition)
+                    defer(100, _wait_condition, deferred, condition)
                 elif isinstance(condition, dict) and "condition" in condition and \
                         callable(condition["condition"]):
-                    period = condition.get("period", DEFAULT_CONDITION_POLL_TIME)
+                    period = condition.get("period", 100)
                     defer(period, _wait_condition, deferred, **condition)
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
@@ -75,7 +73,7 @@ class DeferringTextTestRunner(TextTestRunner):
                         partial(defer, 0, _continue_testing, deferred)
                     )
                 else:
-                    defer(0, _continue_testing, deferred)
+                    defer(10, _continue_testing, deferred)
 
             except StopIteration:
                 _stop_testing()
@@ -84,29 +82,21 @@ class DeferringTextTestRunner(TextTestRunner):
             except Exception as e:
                 _handle_error(e)
 
-        def _wait_condition(
-            deferred, condition,
-            period=DEFAULT_CONDITION_POLL_TIME,
-            timeout=DEFAULT_CONDITION_TIMEOUT,
-            start_time=None
-        ):
+        def _wait_condition(deferred, condition, period=100, timeout=10000, start_time=None):
             if start_time is None:
                 start_time = time.time()
 
             try:
                 send_value = condition()
             except Exception as e:
-                _continue_testing(deferred, throw_value=e)
+                defer(10, _continue_testing, deferred, throw_value=e)
                 return
 
             if send_value:
-                _continue_testing(deferred, send_value=send_value)
+                defer(10, _continue_testing, deferred, send_value=send_value)
             elif (time.time() - start_time) * 1000 >= timeout:
-                error = TimeoutError(
-                    'Condition not fulfilled within {:.2f} seconds'
-                    .format(timeout / 1000)
-                )
-                _continue_testing(deferred, throw_value=error)
+                self.stream.writeln("Condition timeout, continue anyway.")
+                defer(10, _continue_testing, deferred)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 
@@ -164,4 +154,4 @@ class DeferringTextTestRunner(TextTestRunner):
             else:
                 self.stream.write("\n")
 
-        _start_testing()
+        sublime.set_timeout(_start_testing, 10)

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -10,6 +10,8 @@ def defer(delay, callback, *args, **kwargs):
     sublime.set_timeout(partial(callback, *args, **kwargs), delay)
 
 
+DEFAULT_CONDITION_POLL_TIME = 17
+DEFAULT_CONDITION_TIMEOUT = 4000
 AWAIT_WORKER = 'AWAIT_WORKER'
 # Extract `set_timeout_async`, t.i. *avoid* late binding, in case a user
 # patches it
@@ -48,7 +50,7 @@ class DeferringTextTestRunner(TextTestRunner):
                     startTestRun()
                 try:
                     deferred = test(result)
-                    defer(10, _continue_testing, deferred)
+                    _continue_testing(deferred)
 
                 except Exception as e:
                     _handle_error(e)
@@ -61,10 +63,10 @@ class DeferringTextTestRunner(TextTestRunner):
                     condition = deferred.send(send_value)
 
                 if callable(condition):
-                    defer(100, _wait_condition, deferred, condition)
+                    defer(0, _wait_condition, deferred, condition)
                 elif isinstance(condition, dict) and "condition" in condition and \
                         callable(condition["condition"]):
-                    period = condition.get("period", 100)
+                    period = condition.get("period", DEFAULT_CONDITION_POLL_TIME)
                     defer(period, _wait_condition, deferred, **condition)
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
@@ -73,7 +75,7 @@ class DeferringTextTestRunner(TextTestRunner):
                         partial(defer, 0, _continue_testing, deferred)
                     )
                 else:
-                    defer(10, _continue_testing, deferred)
+                    defer(0, _continue_testing, deferred)
 
             except StopIteration:
                 _stop_testing()
@@ -82,24 +84,29 @@ class DeferringTextTestRunner(TextTestRunner):
             except Exception as e:
                 _handle_error(e)
 
-        def _wait_condition(deferred, condition, period=100, timeout=10000, start_time=None):
+        def _wait_condition(
+            deferred, condition,
+            period=DEFAULT_CONDITION_POLL_TIME,
+            timeout=DEFAULT_CONDITION_TIMEOUT,
+            start_time=None
+        ):
             if start_time is None:
                 start_time = time.time()
 
             try:
                 send_value = condition()
             except Exception as e:
-                defer(10, _continue_testing, deferred, throw_value=e)
+                _continue_testing(deferred, throw_value=e)
                 return
 
             if send_value:
-                defer(10, _continue_testing, deferred, send_value=send_value)
+                _continue_testing(deferred, send_value=send_value)
             elif (time.time() - start_time) * 1000 >= timeout:
                 error = TimeoutError(
                     'Condition not fulfilled within {:.2f} seconds'
                     .format(timeout / 1000)
                 )
-                defer(10, _continue_testing, deferred, throw_value=error)
+                _continue_testing(deferred, throw_value=error)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 
@@ -157,4 +164,4 @@ class DeferringTextTestRunner(TextTestRunner):
             else:
                 self.stream.write("\n")
 
-        sublime.set_timeout(_start_testing, 10)
+        _start_testing()

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -95,8 +95,11 @@ class DeferringTextTestRunner(TextTestRunner):
             if send_value:
                 defer(10, _continue_testing, deferred, send_value=send_value)
             elif (time.time() - start_time) * 1000 >= timeout:
-                self.stream.writeln("Condition timeout, continue anyway.")
-                defer(10, _continue_testing, deferred)
+                error = TimeoutError(
+                    'Condition not fulfilled within {:.2f} seconds'
+                    .format(timeout / 1000)
+                )
+                defer(10, _continue_testing, deferred, throw_value=error)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -10,6 +10,8 @@ def defer(delay, callback, *args, **kwargs):
     sublime.set_timeout(partial(callback, *args, **kwargs), delay)
 
 
+DEFAULT_CONDITION_POLL_TIME = 17
+DEFAULT_CONDITION_TIMEOUT = 4000
 AWAIT_WORKER = 'AWAIT_WORKER'
 # Extract `set_timeout_async`, t.i. *avoid* late binding, in case a user
 # patches it
@@ -48,7 +50,7 @@ class DeferringTextTestRunner(TextTestRunner):
                     startTestRun()
                 try:
                     deferred = test(result)
-                    defer(10, _continue_testing, deferred)
+                    _continue_testing(deferred)
 
                 except Exception as e:
                     _handle_error(e)
@@ -61,10 +63,10 @@ class DeferringTextTestRunner(TextTestRunner):
                     condition = deferred.send(send_value)
 
                 if callable(condition):
-                    defer(100, _wait_condition, deferred, condition)
+                    defer(0, _wait_condition, deferred, condition)
                 elif isinstance(condition, dict) and "condition" in condition and \
                         callable(condition["condition"]):
-                    period = condition.get("period", 100)
+                    period = condition.get("period", DEFAULT_CONDITION_POLL_TIME)
                     defer(period, _wait_condition, deferred, **condition)
                 elif isinstance(condition, int):
                     defer(condition, _continue_testing, deferred)
@@ -73,7 +75,7 @@ class DeferringTextTestRunner(TextTestRunner):
                         partial(defer, 0, _continue_testing, deferred)
                     )
                 else:
-                    defer(10, _continue_testing, deferred)
+                    defer(0, _continue_testing, deferred)
 
             except StopIteration:
                 _stop_testing()
@@ -82,21 +84,29 @@ class DeferringTextTestRunner(TextTestRunner):
             except Exception as e:
                 _handle_error(e)
 
-        def _wait_condition(deferred, condition, period=100, timeout=10000, start_time=None):
+        def _wait_condition(
+            deferred, condition,
+            period=DEFAULT_CONDITION_POLL_TIME,
+            timeout=DEFAULT_CONDITION_TIMEOUT,
+            start_time=None
+        ):
             if start_time is None:
                 start_time = time.time()
 
             try:
                 send_value = condition()
             except Exception as e:
-                defer(10, _continue_testing, deferred, throw_value=e)
+                _continue_testing(deferred, throw_value=e)
                 return
 
             if send_value:
-                defer(10, _continue_testing, deferred, send_value=send_value)
+                _continue_testing(deferred, send_value=send_value)
             elif (time.time() - start_time) * 1000 >= timeout:
-                self.stream.writeln("Condition timeout, continue anyway.")
-                defer(10, _continue_testing, deferred)
+                error = TimeoutError(
+                    'Condition not fulfilled within {:.2f} seconds'
+                    .format(timeout / 1000)
+                )
+                _continue_testing(deferred, throw_value=error)
             else:
                 defer(period, _wait_condition, deferred, condition, period, timeout, start_time)
 
@@ -154,4 +164,4 @@ class DeferringTextTestRunner(TextTestRunner):
             else:
                 self.stream.write("\n")
 
-        sublime.set_timeout(_start_testing, 10)
+        _start_testing()

--- a/unittesting/core/st3/runner.py
+++ b/unittesting/core/st3/runner.py
@@ -7,7 +7,7 @@ import sublime
 
 def defer(delay, callback, *args, **kwargs):
     # Rely on late binding in case a user patches it
-    sublime.set_timeout(lambda: callback(*args, **kwargs), delay)
+    sublime.set_timeout(partial(callback, *args, **kwargs), delay)
 
 
 AWAIT_WORKER = 'AWAIT_WORKER'

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -62,13 +62,6 @@ class UnitTestingMixin(object):
 
         return None
 
-    @property
-    def current_test_file(self):
-        current_file = sublime.active_window().active_view().file_name()
-        if current_file and current_file.endswith(".py"):
-            current_file = os.path.basename(current_file)
-        return current_file
-
     def input_parser(self, package):
         m = re.match(r'([^:]+):(.+)', package)
         if m:

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -35,11 +35,11 @@ def casedpath(path):
 
 def relative_to_spp(path):
     spp = sublime.packages_path()
-    spp_real = casedpath(os.path.realpath(spp))
-    for p in [path, casedpath(os.path.realpath(path))]:
-        for sp in [spp, spp_real]:
-            if p.startswith(sp + os.sep):
-                return p[len(sp):]
+    path = os.path.realpath(path)
+    for f in os.listdir(spp):
+        f2 = os.path.realpath(os.path.join(spp, f))
+        if path.startswith(f2 + os.sep):
+            return os.sep + os.path.join(f, os.path.relpath(path, f2))
     return None
 
 

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -17,6 +17,7 @@ DEFAULT_SETTINGS = {
     "pattern": "test*.py",
     "async": False,
     "deferred": False,
+    "fast_timings": False,
     "verbosity": 2,
     "output": None,
     "reload_package_on_testing": True,

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -17,7 +17,7 @@ DEFAULT_SETTINGS = {
     "pattern": "test*.py",
     "async": False,
     "deferred": False,
-    "fast_timings": False,
+    "legacy_runner": True,
     "verbosity": 2,
     "output": None,
     "reload_package_on_testing": True,

--- a/unittesting/test_current.py
+++ b/unittesting/test_current.py
@@ -56,9 +56,12 @@ class UnitTestingCurrentFileCommand(UnitTestingCommand):
         file_name = os.path.basename(current_file)
         if file_name and fnmatch(file_name, settings['pattern']):
             test_file = file_name
-            window.settings().set('last_test_file', test_file)
+            window.settings().set('UnitTesting.last_test_file', test_file)
         else:
-            test_file = window.settings().get('last_test_file') or current_file
+            test_file = (
+                window.settings().get('UnitTesting.last_test_file')
+                or current_file
+            )
 
         sublime.set_timeout_async(
             lambda: super(UnitTestingCurrentFileCommand, self).run(

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -6,8 +6,8 @@ import logging
 from unittest import TextTestRunner, TestSuite
 from .core import (
     TestLoader,
-    FastDeferringTextTestRunner,
     DeferringTextTestRunner,
+    LegacyDeferringTextTestRunner,
     DeferrableTestCase
 )
 from .mixin import UnitTestingMixin
@@ -67,8 +67,8 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
             )
             # use deferred test runner or default test runner
             if settings["deferred"]:
-                if settings["fast_timings"]:
-                    testRunner = FastDeferringTextTestRunner(stream, verbosity=settings["verbosity"])
+                if settings["legacy_runner"]:
+                    testRunner = LegacyDeferringTextTestRunner(stream, verbosity=settings["verbosity"])
                 else:
                     testRunner = DeferringTextTestRunner(stream, verbosity=settings["verbosity"])
             else:

--- a/unittesting/test_package.py
+++ b/unittesting/test_package.py
@@ -4,7 +4,12 @@ import sys
 import os
 import logging
 from unittest import TextTestRunner, TestSuite
-from .core import TestLoader, DeferringTextTestRunner, DeferrableTestCase
+from .core import (
+    TestLoader,
+    FastDeferringTextTestRunner,
+    DeferringTextTestRunner,
+    DeferrableTestCase
+)
 from .mixin import UnitTestingMixin
 from .const import DONE_MESSAGE
 from .utils import ProgressBar, StdioSplitter
@@ -62,7 +67,10 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
             )
             # use deferred test runner or default test runner
             if settings["deferred"]:
-                testRunner = DeferringTextTestRunner(stream, verbosity=settings["verbosity"])
+                if settings["fast_timings"]:
+                    testRunner = FastDeferringTextTestRunner(stream, verbosity=settings["verbosity"])
+                else:
+                    testRunner = DeferringTextTestRunner(stream, verbosity=settings["verbosity"])
             else:
                 self.verify_testsuite(tests)
                 testRunner = TextTestRunner(stream, verbosity=settings["verbosity"])


### PR DESCRIPTION
Closes #146 
Closes #147 
Closes #148 
Closes #149 

Because in the end #146 and parts of #147 are breaking, we need to put them behind a feature flag. I used `fast_timings` here. The default is for obvious reasons 'False'. I recommend to deprecate the old `DeferringTextTestRunner` because it has no advantage over the new one. 

I back-ported as many features as possible to the old one though. 

All users get:

- yield <condition> throws and sends its value back (part of #147)
- yield AWAIT_WORKER (part of #146)

Users opting 'fast_timings' get:

- Super-fast tests 😁 
- yield condition will not continue but err on timeout
- For functional test, allow running single-threaded. This will make coverage happy, and allows ticking the time using plain `yield`. I highly recommend using this if the app/plugin you're building allows it.

Notable fix

- `add/doCleanups` works


Why is the system now so fast?

We do not add implicit waiting time anymore. 

What to do if the test fail after opting 'fast_timings'?

Essentially, *add* explicit waiting time using one of the `yield` forms. E.g. for the failing GitSavvy tests (discussed in #146) it is enough to `yield AWAIT_WORKER` on `tearDown`. This is reasonable, and it doesn't make the tests as slow as before. The runtime of the GitSavvy test is still cut in half. (Note that AWAIT_WORKER is introduced by this PR, you usually used number guessing like `yield 300` et.al. before.)



