### PR TITLE
Fix scrolling of output panel

### DIFF
--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -49,12 +49,11 @@ class OutputPanel:
             while self.text_queue:
                 text += self.text_queue.popleft()
 
-        self.output_view.set_read_only(False)
         self.output_view.run_command(
             'append',
-            {'characters': text, 'force': True, 'scroll_to_end': True}
+            {'characters': text, 'force': True}
         )
-        self.output_view.set_read_only(True)
+        self.output_view.show(self.output_view.size())
 
     def flush(self):
         self._write()


### PR DESCRIPTION
If the output is wide enough so that it introduces horizontal scrolling,
the built in `scroll_to_end` functionality breaks. We instead call
`view.scroll(...)` which works as intended.

`set_read_only` is not necessary bc we set `force: True`.