### PR TITLE
Implement `expectedFailure` for the DeferrableTestCase

### DIFF
--- a/tests/test_expected_failures.py
+++ b/tests/test_expected_failures.py
@@ -1,0 +1,55 @@
+from unittest.case import _ExpectedFailure, _UnexpectedSuccess
+from unittesting import DeferrableTestCase, expectedFailure
+
+
+class TestExpectedFailures(DeferrableTestCase):
+    def test_expected_failure_coroutine(self):
+        @expectedFailure
+        def testitem():
+            yield
+            1 / 0
+
+        try:
+            yield from testitem()
+        except _ExpectedFailure:
+            pass
+        else:
+            self.fail('Expected _ExpectedFailure')
+
+    def test_expected_failure(self):
+        @expectedFailure
+        def testitem():
+            1 / 0
+
+        try:
+            yield from testitem()
+        except _ExpectedFailure:
+            pass
+        else:
+            self.fail('Expected _ExpectedFailure')
+
+    def test_unexpected_success_coroutine(self):
+
+        @expectedFailure
+        def testitem():
+            yield
+
+        try:
+            yield from testitem()
+        except _UnexpectedSuccess:
+            pass
+        else:
+            self.fail('Expected _UnexpectedSuccess')
+
+    def test_unexpected_success(self):
+
+        @expectedFailure
+        def testitem():
+            ...
+
+        try:
+            yield from testitem()
+        except _UnexpectedSuccess:
+            pass
+        else:
+            self.fail('Expected _UnexpectedSuccess')

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,4 +1,4 @@
-from .core import DeferrableTestCase, AWAIT_WORKER
+from .core import DeferrableTestCase, AWAIT_WORKER, expectedFailure
 from .scheduler import UnitTestingRunSchedulerCommand
 from .scheduler import run_scheduler
 from .test_package import UnitTestingCommand
@@ -23,5 +23,6 @@ __all__ = [
     "UnitTestingSyntaxCommand",
     "UnitTestingSyntaxCompatibilityCommand",
     "UnitTestingColorSchemeCommand",
-    "AWAIT_WORKER"
+    "AWAIT_WORKER",
+    "expectedFailure"
 ]

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,6 +1,6 @@
 from .st3.runner import DeferringTextTestRunner, AWAIT_WORKER
 from .st3.legacy_runner import LegacyDeferringTextTestRunner
-from .st3.case import DeferrableTestCase
+from .st3.case import DeferrableTestCase, expectedFailure
 from .st3.suite import DeferrableTestSuite
 from .loader import UnitTestingLoader as TestLoader
 
@@ -10,5 +10,6 @@ __all__ = [
     "LegacyDeferringTextTestRunner",
     "DeferrableTestCase",
     "DeferrableTestSuite",
-    "AWAIT_WORKER"
+    "AWAIT_WORKER",
+    "expectedFailure"
 ]

--- a/unittesting/core/st3/case.py
+++ b/unittesting/core/st3/case.py
@@ -1,8 +1,22 @@
+from functools import wraps
 import sys
 import unittest
 import warnings
 from unittest.case import _ExpectedFailure, _UnexpectedSuccess, SkipTest, _Outcome
 from ...utils import isiterable
+
+
+def expectedFailure(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            deferred = func(*args, **kwargs)
+            if isiterable(deferred):
+                yield from deferred
+        except Exception:
+            raise _ExpectedFailure(sys.exc_info())
+        raise _UnexpectedSuccess
+    return wrapper
 
 
 class DeferrableTestCase(unittest.TestCase):


### PR DESCRIPTION
The built in `expectedFailure` does not expect coroutines as functions, so we must re-implement this decorator.