### PR TITLE
Improved error text of regexp assertions.

### DIFF
--- a/tests/test_3141596.py
+++ b/tests/test_3141596.py
@@ -97,8 +97,10 @@ def prepare_package(package, output=None, syntax_test=False, syntax_compatibilit
 class UnitTestingTestCase(DeferrableTestCase):
 
     def assertRegexContains(self, txt, expr, msg=None):
-        m = re.search(expr, txt, re.MULTILINE)
-        self.assertIsNotNone(m, msg)
+        if re.search(expr, txt, re.MULTILINE) is None:
+            self.fail("String {!r} does not contain regexp {!r}.".format(
+                txt, expr
+            ))
 
     def assertOk(self, txt, msg=None):
         self.assertRegexContains(txt, r'^OK', msg)


### PR DESCRIPTION
When `assertRegexContains` fails, provide a useful error message.