### PR TITLE
Asyncio in run tests script

### DIFF
--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,6 +1,6 @@
 from .core import DeferrableTestCase, AWAIT_WORKER, expectedFailure
 from .scheduler import UnitTestingRunSchedulerCommand
-from .scheduler import run_scheduler
+from .scheduler import UnitTestingPingCommand
 from .package import UnitTestingCommand
 from .coverage import UnitTestingCoverageCommand
 from .current import UnitTestingCurrentFileCommand
@@ -14,7 +14,7 @@ from .color_scheme import UnitTestingColorSchemeCommand
 __all__ = [
     "DeferrableTestCase",
     "UnitTestingRunSchedulerCommand",
-    "run_scheduler",
+    "UnitTestingPingCommand",
     "UnitTestingCommand",
     "UnitTestingCoverageCommand",
     "UnitTestingCurrentFileCommand",

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -2,6 +2,7 @@ from collections import ChainMap
 import os
 import sys
 import re
+import socket
 from glob import glob
 
 from .utils import reload_package
@@ -103,20 +104,17 @@ class UnitTestingMixin(object):
         return outfile
 
     def load_stream(self, package, settings):
-        output = settings["output"]
-        if not output or output == "<panel>":
+        tcp_port = settings.get("tcp_port")
+        if tcp_port is None:
+            print("tcp_port is None :(")
             output_panel = OutputPanel(
                 'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)')
             output_panel.show()
             stream = output_panel
         else:
-            if not os.path.isabs(output):
-                if sublime.platform() == "windows":
-                    output = output.replace("/", "\\")
-                output = os.path.join(sublime.packages_path(), package, output)
-            if os.path.exists(output):
-                os.remove(output)
-            stream = open(output, "w")
+            print("tcp_port is not None :)")
+            conn = socket.create_connection(('localhost', tcp_port))
+            stream = conn.makefile('w')
 
         return stream
 

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -106,13 +106,11 @@ class UnitTestingMixin(object):
     def load_stream(self, package, settings):
         tcp_port = settings.get("tcp_port")
         if tcp_port is None:
-            print("tcp_port is None :(")
             output_panel = OutputPanel(
                 'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)')
             output_panel.show()
             stream = output_panel
         else:
-            print("tcp_port is not None :)")
             conn = socket.create_connection(('localhost', tcp_port))
             stream = conn.makefile('w')
 

--- a/unittesting/scheduler.py
+++ b/unittesting/scheduler.py
@@ -4,20 +4,6 @@ import sublime_plugin
 from .utils import JsonFile
 
 
-_is_loaded = False
-
-
-def set_loaded(b):
-    global _is_loaded
-    print("setting _is_loaded to", b)
-    _is_loaded = b
-
-
-def is_loaded():
-    global _is_loaded
-    return _is_loaded
-
-
 class Unit:
 
     def __init__(self, s):

--- a/ut.py
+++ b/ut.py
@@ -26,6 +26,7 @@ sys.modules["unittesting"] = unittesting
 
 
 from unittesting import UnitTestingRunSchedulerCommand  # noqa: F401
+from unittesting import UnitTestingPingCommand  # noqa: F401
 from unittesting import UnitTestingCommand  # noqa: F401
 from unittesting import UnitTestingCoverageCommand  # noqa: F401
 from unittesting import UnitTestingCurrentFileCommand  # noqa: F401
@@ -38,6 +39,7 @@ from unittesting import UnitTestingColorSchemeCommand  # noqa: F401
 
 __all__ = [
     "UnitTestingRunSchedulerCommand",
+    "UnitTestingPingCommand",
     "UnitTestingCommand",
     "UnitTestingCoverageCommand",
     "UnitTestingCurrentFileCommand",


### PR DESCRIPTION
Only tested for Linux and tested locally. So my expectation is that the CI will fail.
This branch should evolve more.

I have also replaced the polling behavior to check whether the UnitTesting plugin is loaded by a UnitTestingSchedulerPingCommand class. The run_tests.py script calls this command via `subl --command unit_testing_scheduler_ping`. Once UnitTesting is loaded, that command will write to a flie. In run_tests.py we check whether that file exists. If it exists, then we know that UnitTesting is loaded.