### PR TITLE
Try to avoid losing focus after file is close

### DIFF
--- a/sbin/run_tests.py
+++ b/sbin/run_tests.py
@@ -96,7 +96,7 @@ def wait_for_output(path, schedule, timeout=10):
 
 
 def start_sublime_text():
-    subprocess.Popen("subl &", shell=True)
+    subprocess.Popen("subl --stay &", shell=True)
 
 
 def kill_sublime_text():


### PR DESCRIPTION
ST3 opens a temporary file (on mac it's at /tmp/subl stdin XXXXX) on
running a `subl &` command from  python. If that file is then closed
the focus is returned to the terminal which can negatively affect
tests that rely on focus being in ST windows.

This is an attempt to avoid that - `--stay` option makes sure that
ST window stays focused after file opened by `subl &` command is closed.

The fact that ST3 opens that file in the first place seems like a bug
and it looks like ST4 doesn't do it anymore.