### PR TITLE
Strip whitespace when reading `.python-version`

### DIFF
--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -51,7 +51,7 @@ class UnitTestingMixin(object):
         if sublime.version() < '4000':
             return "3.3"
         try:
-            version = sublime.load_resource("Packages/{}/.python-version".format(package))
+            version = sublime.load_resource("Packages/{}/.python-version".format(package)).strip()
         except FileNotFoundError:
             version = "3.3"
         return version


### PR DESCRIPTION
Typically when we read a file we at least expect a `\n` at EOF.

For example, SublimeLinter always had a ".python-version" file, its contents 
currently being `3.3\r\n`.  