### PR TITLE
Fix macOS kLSNoExecutableErr install error

### DIFF
--- a/sbin/install_sublime_text.sh
+++ b/sbin/install_sublime_text.sh
@@ -104,6 +104,12 @@ if [ $(uname) = 'Darwin'  ]; then
             echo '{"close_windows_when_empty": false }' > "$STP/User/Preferences.sublime-settings"
         fi
 
+        # Workaround for an issue on macOS 11 where opening the app would
+        # randomly fail with kLSNoExecutableErr.
+        # See https://github.com/SublimeText/UnitTesting/issues/200
+        /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+            -f "$HOME/Applications/$SUBLIME_TEXT.app"
+
         # make `subl` available
         open "$HOME/Applications/$SUBLIME_TEXT.app"
         sleep 2

--- a/scripts/install_sublime_text.sh
+++ b/scripts/install_sublime_text.sh
@@ -105,6 +105,12 @@ if [ $(uname) = 'Darwin'  ]; then
             echo '{"close_windows_when_empty": false }' > "$STP/User/Preferences.sublime-settings"
         fi
 
+        # Workaround for an issue on macOS 11 where opening the app would
+        # randomly fail with kLSNoExecutableErr.
+        # See https://github.com/SublimeText/UnitTesting/issues/200
+        /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+            -f "$HOME/Applications/$SUBLIME_TEXT.app"
+
         # make `subl` available
         open "$HOME/Applications/$SUBLIME_TEXT.app"
         sleep 2


### PR DESCRIPTION
This fixes a sporadic error installing Sublime on macOS 11 that has recently been causing problems where it would fail with the error:

The application cannot be opened for an unexpected reason, error=Error Domain=NSOSStatusErrorDomain Code=-10827 "kLSNoExecutableErr: The executable is missing" UserInfo={_LSLine=3845, _LSFunction=_LSOpenStuffCallLocal}

This forces Sublime to be registered with the launch services database. I don't fully understand the underlying cause, but I have been testing this fix on repeat without any errors.

Fixes #200