### PR TITLE
fix: st4 download link

### DIFF
--- a/sbin/install_sublime_text.sh
+++ b/sbin/install_sublime_text.sh
@@ -37,7 +37,7 @@ if [ $SUBLIME_TEXT_VERSION -ge 4 ] && [ "$SUBLIME_TEXT_ARCH" != "x64" ]; then
 fi
 
 if [ $SUBLIME_TEXT_VERSION -ge 4 ]; then
-    STWEB="https://www.sublimetext.com/download"
+    STWEB="https://www.sublimetext.com/download_thanks"
 else
     STWEB="https://www.sublimetext.com/$SUBLIME_TEXT_VERSION"
 fi


### PR DESCRIPTION
This should fix a "could not download Sublime Text binary" error:

![Screenshot from 2022-05-31 09-46-47](https://user-images.githubusercontent.com/44148/171132771-e5849bcd-b7ae-415e-85ef-6e7f8161a04e.png)

https://github.com/gerardroche/sublime-monokai-free/runs/6666517409?check_suite_focus=true

It's difficult to test this because I had to hack the code to change the urls to point to my forked repository. When I tested I still got another error trying to install `xz-utils`, but that might just be because of the way I was testing it.

![Screenshot from 2022-05-31 09-45-22](https://user-images.githubusercontent.com/44148/171132969-db682b2e-0778-4269-9562-c8a8ce8b8658.png)

https://github.com/gerardroche/sublime-monokai-free/runs/6667187169?check_suite_focus=true