### PR TITLE
Add `condition_timeout` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ UnitTesting could be configured by providing the following settings in `unittest
 | generate_html_report        | generate coverage report for coverage                               | false         |
 | capture_console             | capture stdout and stderr in the test output                        | false         |
 | failfast                    | stop early if a test fails                                          | false         |
+| condition_timeout           | default timeout in ms for callables invoked via `yield`             | 4000          |
 
 ## Others
 

--- a/unittesting/core/py33/runner.py
+++ b/unittesting/core/py33/runner.py
@@ -91,7 +91,7 @@ class DeferringTextTestRunner(TextTestRunner):
             timeout=None,
             start_time=None
         ):
-            timeout = self.condition_timeout or timeout
+            timeout = timeout or self.condition_timeout
             if start_time is None:
                 start_time = time.time()
 

--- a/unittesting/core/py33/runner.py
+++ b/unittesting/core/py33/runner.py
@@ -20,6 +20,7 @@ run_on_worker = sublime.set_timeout_async
 
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
+    condition_timeout = DEFAULT_CONDITION_TIMEOUT
 
     def run(self, test):
         """Run the given test case or test suite."""
@@ -87,9 +88,10 @@ class DeferringTextTestRunner(TextTestRunner):
         def _wait_condition(
             deferred, condition,
             period=DEFAULT_CONDITION_POLL_TIME,
-            timeout=DEFAULT_CONDITION_TIMEOUT,
+            timeout=None,
             start_time=None
         ):
+            timeout = self.condition_timeout or timeout
             if start_time is None:
                 start_time = time.time()
 

--- a/unittesting/core/py38/runner.py
+++ b/unittesting/core/py38/runner.py
@@ -20,6 +20,7 @@ run_on_worker = sublime.set_timeout_async
 
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
+    condition_timeout = DEFAULT_CONDITION_TIMEOUT
 
     def run(self, test):
         """Run the given test case or test suite."""
@@ -90,9 +91,10 @@ class DeferringTextTestRunner(TextTestRunner):
         def _wait_condition(
             deferred, condition,
             period=DEFAULT_CONDITION_POLL_TIME,
-            timeout=DEFAULT_CONDITION_TIMEOUT,
+            timeout=None,
             start_time=None
         ):
+            timeout = timeout or self.condition_timeout
             if start_time is None:
                 start_time = time.time()
 

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -26,7 +26,8 @@ DEFAULT_SETTINGS = {
     "coverage_on_worker_thread": False,  # experimental
     "generate_html_report": False,
     "capture_console": False,
-    "failfast": False
+    "failfast": False,
+    "condition_timeout": 4000,
 }
 
 

--- a/unittesting/package.py
+++ b/unittesting/package.py
@@ -92,8 +92,7 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                         raise Exception("`legacy_runner=True` is deprecated.")
                     testRunner = DeferringTextTestRunner(
                         stream, verbosity=settings["verbosity"], failfast=settings['failfast'])
-                    if "condition_timeout" in settings:
-                        testRunner.condition_timeout = int(settings["condition_timeout"])
+                    testRunner.condition_timeout = settings["condition_timeout"]
                 else:
                     self.verify_testsuite(tests)
                     testRunner = TextTestRunner(stream, verbosity=settings["verbosity"], failfast=settings['failfast'])

--- a/unittesting/package.py
+++ b/unittesting/package.py
@@ -92,6 +92,8 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                         raise Exception("`legacy_runner=True` is deprecated.")
                     testRunner = DeferringTextTestRunner(
                         stream, verbosity=settings["verbosity"], failfast=settings['failfast'])
+                    if "condition_timeout" in settings:
+                        testRunner.condition_timeout = int(settings["condition_timeout"])
                 else:
                     self.verify_testsuite(tests)
                     testRunner = TextTestRunner(stream, verbosity=settings["verbosity"], failfast=settings['failfast'])


### PR DESCRIPTION
@randy3k: for your evaluation. Feel free to reject this if you don't deem it appropriate. My motivation is that, during development, 4 secs is quite a long time to wait for a failure, so I would just like to crash sooner.
