### PR TITLE
Add ColorSchemeUnit support

### DIFF
--- a/actions/run-color-scheme-tests/action.yaml
+++ b/actions/run-color-scheme-tests/action.yaml
@@ -1,0 +1,19 @@
+name: Run color scheme tests
+description: Run color scheme tests
+inputs:
+  package-name:
+    description: Package name. Derived from setup step if empty.
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        . $GITHUB_ACTION_PATH/../../scripts/utils.sh
+
+        InstallPackage "ColorSchemeUnit" "https://github.com/gerardroche/sublime-color-scheme-unit"
+
+        PACKAGE_FROM_INPUTS="${{ inputs.package-name }}"
+        PACKAGE="${PACKAGE_FROM_INPUTS:-$PACKAGE}"
+
+        python3 "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE" --color-scheme-test
+      shell: bash


### PR DESCRIPTION
Allows running the ColorSchemeUnit tests via

```
      - name: Color Scheme Test
        uses: SublimeText/UnitTesting/actions/run-color-scheme-tests@v1

```