### PR TITLE
Add ColorSchemeUnit support

### DIFF
--- a/actions/run-color-scheme-tests/action.yaml
+++ b/actions/run-color-scheme-tests/action.yaml
@@ -1,0 +1,19 @@
+name: Run color scheme tests
+description: Run color scheme tests
+inputs:
+  package-name:
+    description: Package name. Derived from setup step if empty.
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        . $GITHUB_ACTION_PATH/../../scripts/utils.sh
+
+        InstallPackage "ColorSchemeUnit" "https://github.com/gerardroche/sublime-color-scheme-unit"
+
+        PACKAGE_FROM_INPUTS="${{ inputs.package-name }}"
+        PACKAGE="${PACKAGE_FROM_INPUTS:-$PACKAGE}"
+
+        python3 "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE" --color-scheme-test
+      shell: bash


### PR DESCRIPTION
Allows running the ColorSchemeUnit tests.

Example

```yaml
name: Continuous Integration

on: [push, pull_request]

env:
  PACKAGE: MonokaiFree

jobs:
  tests:
    strategy:
      fail-fast: false
      matrix:
        st-version: [3, 4]
        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
    runs-on: ${{ matrix.os }}
    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - name: Setup
        uses: SublimeText/UnitTesting/actions/setup@v1
        with:
          sublime-text-version: ${{ matrix.st-version }}
          package-name: ${{ env.PACKAGE }}

      - name: Color Scheme Tests
        uses: SublimeText/UnitTesting/actions/run-color-scheme-tests@v1

```