### PR TITLE
Disable submitting usage information

### DIFF
--- a/sbin/install_package_control.ps1
+++ b/sbin/install_package_control.ps1
@@ -16,7 +16,7 @@ try{
 
     if (-not (test-path $PC_SETTINGS)) {
         write-verbose "creating Package Control.sublime-settings"
-        "{`"ignore_vcs_packages`": true }" | out-file -filepath $PC_SETTINGS -encoding ascii
+        "{`"ignore_vcs_packages`": true, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding ascii
     }
 
     $PCH_PATH = "$STP\0_install_package_control_helper"

--- a/sbin/install_package_control.sh
+++ b/sbin/install_package_control.sh
@@ -50,7 +50,7 @@ fi
 if [ ! -f "$STP/User/Package Control.sublime-settings" ]; then
     echo creating Package Control.sublime-settings
     # make sure Pakcage Control does not complain
-    echo '{"ignore_vcs_packages": true }' > "$STP/User/Package Control.sublime-settings"
+    echo '{"ignore_vcs_packages": true, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
 fi
 
 PCH_PATH="$STP/0_install_package_control_helper"

--- a/scripts/install_package_control.ps1
+++ b/scripts/install_package_control.ps1
@@ -22,7 +22,7 @@ $PC_SETTINGS = "C:\st\Data\Packages\User\Package Control.sublime-settings"
 
 if (-not (test-path $PC_SETTINGS)) {
     write-verbose "creating Package Control.sublime-settings"
-    "{`"auto_upgrade`": false }" | out-file -filepath $PC_SETTINGS -encoding ascii
+    "{`"auto_upgrade`": false, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding ascii
 }
 
 $PCH_PATH = "$STP\0_install_package_control_helper"

--- a/scripts/install_package_control.sh
+++ b/scripts/install_package_control.sh
@@ -51,7 +51,7 @@ if [ ! -f "$STP/User/Package Control.sublime-settings" ]; then
     echo creating Package Control.sublime-settings
     [ ! -d "$STP/User" ] && mkdir -p "$STP/User"
     # make sure Pakcage Control does not complain
-    echo '{"auto_upgrade": false }' > "$STP/User/Package Control.sublime-settings"
+    echo '{"auto_upgrade": false, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
 fi
 
 PCH_PATH="$STP/0_install_package_control_helper"


### PR DESCRIPTION
Installing packages for automated tests is unrelated with real usage.
Thus prevent Package Control from submitting usage stats.