### PR TITLE
build(actions): update codecov/codecov-action to v4

### DIFF
--- a/actions/run-tests/action.yaml
+++ b/actions/run-tests/action.yaml
@@ -38,4 +38,4 @@ runs:
         echo "Please call the action `codecov/codecov-action` directly".
       shell: bash
     - if: inputs.codecov-upload == 'true'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
This fixes some deprecations:

    tests (3, ubuntu-latest)
    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
