### PR TITLE
Fix reloader after PC update

### DIFF
--- a/unittesting/utils/reloader.py
+++ b/unittesting/utils/reloader.py
@@ -1,23 +1,15 @@
 import sublime
 import sublime_plugin
 import os
+import posixpath
 import threading
 import builtins
 import functools
 import importlib
 import sys
-import types
+import traceback
+from inspect import ismodule
 from contextlib import contextmanager
-
-try:
-    from package_control.package_manager import PackageManager
-
-    def is_dependency(pkg_name):
-        return PackageManager()._is_dependency(pkg_name)
-
-except ImportError:
-    def is_dependency(pkg_name):
-        return False
 
 
 class StackMeter:
@@ -49,6 +41,7 @@ def path_contains(a, b):
 
 
 def get_package_modules(pkg_name):
+    # (str) -> Dict[str, ModuleType]
     in_installed_path = functools.partial(
         path_contains,
         os.path.join(
@@ -63,8 +56,10 @@ def get_package_modules(pkg_name):
     )
 
     def module_in_package(module):
-        file = getattr(module, '__file__', '') or ''
-        paths = getattr(module, '__path__', ()) or ''
+        # Other (extracted) ST plugins using python 3.8 have this set to
+        # `None` surprisingly.
+        file = getattr(module, '__file__', None) or ''
+        paths = getattr(module, '__path__', ())
         return (
             in_installed_path(file) or any(map(in_installed_path, paths)) or
             in_package_path(file) or any(map(in_package_path, paths))
@@ -77,13 +72,15 @@ def get_package_modules(pkg_name):
     }
 
 
-# check the link for comments
-# https://github.com/divmain/GitSavvy/blob/599ba3cdb539875568a96a53fafb033b01708a67/common/util/reload.py
-def reload_package(pkg_name, dummy=True, verbose=True):
-    if is_dependency(pkg_name):
-        reload_dependency(pkg_name, dummy, verbose)
-        return
+def package_plugins(pkg_name):
+    return [
+        pkg_name + '.' + posixpath.basename(posixpath.splitext(path)[0])
+        for path in sublime.find_resources("*.py")
+        if posixpath.dirname(path) == 'Packages/' + pkg_name
+    ]
 
+
+def reload_package(pkg_name, dummy=True, verbose=True):
     if pkg_name not in sys.modules:
         dprint("error:", pkg_name, "is not loaded.")
         return
@@ -91,22 +88,42 @@ def reload_package(pkg_name, dummy=True, verbose=True):
     if verbose:
         dprint("begin", fill='=')
 
-    modules = get_package_modules(pkg_name)
+    all_modules = {
+        module_name: module
+        for module_name, module in get_package_modules(pkg_name).items()
+    }
+    plugins = [plugin for plugin in package_plugins(pkg_name)]
 
-    for m in modules:
-        if m in sys.modules:
-            sublime_plugin.unload_module(modules[m])
-            del sys.modules[m]
+    # Tell Sublime to unload plugins
+    for plugin in plugins:
+        module = sys.modules.get(plugin)
+        if module:
+            sublime_plugin.unload_module(module)
 
+    # Unload modules
+    for module_name in all_modules:
+        sys.modules.pop(module_name)
+
+    # Reload packages
     try:
-        with intercepting_imports(modules, verbose), \
-                importing_fromlist_aggresively(modules):
-
-            reload_plugin(pkg_name)
+        with intercepting_imports(all_modules, verbose), importing_fromlist_aggressively(all_modules):
+            for plugin in plugins:
+                sublime_plugin.reload_plugin(plugin)
     except Exception:
         dprint("reload failed.", fill='-')
-        reload_missing(modules, verbose)
-        raise
+        # Rollback modules
+        for name, module in all_modules.items():
+            sys.modules[name] = module
+
+        # Try reloading again to get the commands back. Here esp. the
+        # reload command itself.
+        for plugin in plugins:
+            sublime_plugin.reload_plugin(plugin)
+
+        traceback.print_exc()
+        print('--- Reloading failed. ---')
+        sublime.active_window().status_message('Reloading 💣ed. 😒.')
+        return
 
     if dummy:
         load_dummy(verbose)
@@ -114,28 +131,7 @@ def reload_package(pkg_name, dummy=True, verbose=True):
     if verbose:
         dprint("end", fill='-')
 
-
-def reload_dependency(dependency_name, dummy=True, verbose=True):
-    """
-    Reload.
-
-    Package Control dependencies aren't regular packages, so we don't want to
-    call `sublime_plugin.unload_module` or `sublime_plugin.reload_plugin`.
-    Instead, we manually unload all of the modules in the dependency and then
-    `reload_package` any packages that use that dependency. (We have to manually
-    unload the dependency's modules because calling `reload_package` on a
-    dependent module will not unload the dependency.)
-    """
-    for name in get_package_modules(dependency_name):
-        del sys.modules[name]
-
-    manager = PackageManager()
-    for package in manager.list_packages():
-        if dependency_name in manager.get_dependencies(package):
-            reload_package(package, dummy=False, verbose=verbose)
-
-    if dummy:
-        load_dummy(verbose)
+    sublime.active_window().status_message('Package has been 🙌 reloaded.')
 
 
 def load_dummy(verbose):
@@ -192,26 +188,6 @@ def load_dummy(verbose):
     condition.release()
 
 
-def reload_missing(modules, verbose):
-    missing_modules = {name: module for name, module in modules.items()
-                       if name not in sys.modules}
-    if missing_modules:
-        if verbose:
-            dprint("reload missing modules")
-        for name in missing_modules:
-            if verbose:
-                dprint("reloading missing module", name)
-            sys.modules[name] = modules[name]
-
-
-def reload_plugin(pkg_name):
-    pkg_path = os.path.join(os.path.realpath(sublime.packages_path()), pkg_name)
-    plugins = [pkg_name + "." + os.path.splitext(file_path)[0]
-               for file_path in os.listdir(pkg_path) if file_path.endswith(".py")]
-    for plugin in plugins:
-        sublime_plugin.reload_plugin(plugin)
-
-
 @contextmanager
 def intercepting_imports(modules, verbose):
     finder = FilterFinder(modules, verbose)
@@ -224,7 +200,7 @@ def intercepting_imports(modules, verbose):
 
 
 @contextmanager
-def importing_fromlist_aggresively(modules):
+def importing_fromlist_aggressively(modules):
     orig___import__ = builtins.__import__
 
     @functools.wraps(orig___import__)
@@ -236,7 +212,7 @@ def importing_fromlist_aggresively(modules):
                 fromlist.remove('*')
                 fromlist.extend(getattr(module, '__all__', []))
             for x in fromlist:
-                if isinstance(getattr(module, x, None), types.ModuleType):
+                if ismodule(getattr(module, x, None)):
                     from_name = '{}.{}'.format(module.__name__, x)
                     if from_name in modules:
                         importlib.import_module(from_name)


### PR DESCRIPTION
Fixes #228 

Since the Package Control update to v4 our reloader is broken.  E.g. `PackageManager()._is_dependency(pkg_name)` throws as it's not there anymore.  (Note the leading `_` telling us to not use this method.)

For now, copy the reloader from ~~`AutomaticPackageReloader`~~`GitSavvy` as it seems "newer" and works at least locally.