### PR TITLE
Extend Package Control settings

### DIFF
--- a/sbin/install_package_control.ps1
+++ b/sbin/install_package_control.ps1
@@ -16,7 +16,7 @@ try{
 
     if (-not (test-path $PC_SETTINGS)) {
         write-verbose "creating Package Control.sublime-settings"
-        "{`"ignore_vcs_packages`": true, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding ascii
+        "{`"auto_upgrade`": false, `"ignore_vcs_packages`": true, `"remove_orphaned`": false, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding utf8
     }
 
     $PCH_PATH = "$STP\0_install_package_control_helper"

--- a/sbin/install_package_control.sh
+++ b/sbin/install_package_control.sh
@@ -50,7 +50,7 @@ fi
 if [ ! -f "$STP/User/Package Control.sublime-settings" ]; then
     echo creating Package Control.sublime-settings
     # make sure Pakcage Control does not complain
-    echo '{"ignore_vcs_packages": true, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
+    echo '{"auto_upgrade": false, "ignore_vcs_packages": true, "remove_orphaned": false, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
 fi
 
 PCH_PATH="$STP/0_install_package_control_helper"

--- a/scripts/install_package_control.ps1
+++ b/scripts/install_package_control.ps1
@@ -22,7 +22,7 @@ $PC_SETTINGS = "C:\st\Data\Packages\User\Package Control.sublime-settings"
 
 if (-not (test-path $PC_SETTINGS)) {
     write-verbose "creating Package Control.sublime-settings"
-    "{`"auto_upgrade`": false, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding ascii
+    "{`"auto_upgrade`": false, `"ignore_vcs_packages`": true, `"remove_orphaned`": false, `"submit_usage`": false }" | out-file -filepath $PC_SETTINGS -encoding utf8
 }
 
 $PCH_PATH = "$STP\0_install_package_control_helper"

--- a/scripts/install_package_control.sh
+++ b/scripts/install_package_control.sh
@@ -51,7 +51,7 @@ if [ ! -f "$STP/User/Package Control.sublime-settings" ]; then
     echo creating Package Control.sublime-settings
     [ ! -d "$STP/User" ] && mkdir -p "$STP/User"
     # make sure Pakcage Control does not complain
-    echo '{"auto_upgrade": false, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
+    echo '{"auto_upgrade": false, "ignore_vcs_packages": true, "remove_orphaned": false, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
 fi
 
 PCH_PATH="$STP/0_install_package_control_helper"


### PR DESCRIPTION
Package Control should...

1. not mess with VCS packages
2. not try to remove orphaned packages or libraries
3. not try to auto-upgrade anything automatically.

On Windows use encoding: utf-8 to write settings for formal reasons.
It doesn't make a technical difference though.