### PR TITLE
Exclude sbin/scripts from sublime-package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,7 @@
 /.gitignore                 export-ignore
 /actions/                   export-ignore
 /docker/                    export-ignore
+/sbin/                      export-ignore
+/scripts/                   export-ignore
 /tests/                     export-ignore
 /unittesting.json           export-ignore


### PR DESCRIPTION
Files in sbin and scripts directory are for dedicated use by CI runners.