### PR TITLE
Fix coverage for ST4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,15 +4,25 @@
 
 # Files and directories with the attribute export-ignore won’t be added to
 # archive files. See http://git-scm.com/docs/gitattributes for details.
-/.codecov.yml               export-ignore
-/.coveragerc                export-ignore
-/.flake8                    export-ignore
+
+# Git
 /.gitattributes             export-ignore
 /.github/                   export-ignore
 /.gitignore                 export-ignore
+
+# CI
 /actions/                   export-ignore
 /docker/                    export-ignore
 /sbin/                      export-ignore
 /scripts/                   export-ignore
+
+# Coverage
+/.coveragerc                export-ignore
+/codecov.yml                export-ignore
+
+# Linting
+/.flake8                    export-ignore
+
+# Tests
 /tests/                     export-ignore
 /unittesting.json           export-ignore

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,10 +34,10 @@ jobs:
           install-unittesting: false
       - uses: "./actions/run-tests"
         with:
-          coverage: false
-      # - uses: codecov/codecov-action@v4
-      #   with:
-      #     token: ${{secrets.CODECOV_TOKEN}}
+          coverage: true
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
 
   test-actions:  # with latest released unittesting
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@
 # operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
+# python
+.venv/
 *.pyc
+
+# coverage
 .coverage
+coverage.xml
+htmlcov/
+
+# vagrant
 .vagrant

--- a/actions/run-tests/action.yaml
+++ b/actions/run-tests/action.yaml
@@ -20,16 +20,9 @@ runs:
         PACKAGE="${PACKAGE_FROM_INPUTS:-$PACKAGE}"
 
         if [ "${{ inputs.coverage }}" == "true" ]; then
-          python3 "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE" --coverage
+          python "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE" --coverage
         else
-          python3 "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE"
-        fi
-      shell: bash
-    - if: inputs.coverage == 'true'
-      run: |
-        if [ -f ./.coverage ]; then
-          pip3 install coverage==4.5.4
-          python3 -m coverage xml -o coverage.xml
+          python "$GITHUB_ACTION_PATH/../../scripts/run_tests.py" "$PACKAGE"
         fi
       shell: bash
     - if: inputs.codecov-upload == 'true'

--- a/sbin/install_package_control.ps1
+++ b/sbin/install_package_control.ps1
@@ -27,6 +27,9 @@ try{
     Copy-Item "$BASE\.python-version" "$PCH_PATH\.python-version"
 
     for ($i=1; $i -le 3; $i++) {
+        if (test-path "$PCH_PATH\success") {
+            remove-item "$PCH_PATH\success" -Force
+        }
 
         & "C:\st\sublime_text.exe"
         $startTime = get-date

--- a/sbin/install_package_control.sh
+++ b/sbin/install_package_control.sh
@@ -66,6 +66,8 @@ fi
 # launch sublime text in background
 echo Starting Sublime Text
 for i in {1..3}; do
+    rm -f "$PCH_PATH/success"
+
     subl &
 
     ENDTIME=$(( $(date +%s) + 60 ))

--- a/sbin/pc_helper.py
+++ b/sbin/pc_helper.py
@@ -9,7 +9,14 @@ def plugin_loaded():
         sublime.packages_path(), "0_install_package_control_helper", "log"
     )
 
+    log = open(logfile, "a", encoding="utf-8")
+
+    sys.stdout = log
+    sys.stderr = log
+
     def kill_subl(restart=False):
+        log.close()
+
         if sublime.platform() == "osx":
             cmd = "sleep 1; pkill [Ss]ubl; pkill plugin_host; sleep 1; "
             if restart:
@@ -54,9 +61,8 @@ def plugin_loaded():
             required_libraries=required_libraries
         )
         if missing_libraries:
-            with open(logfile, "a") as f:
-                f.write("missing dependencies:" + "\n")
-                f.write(" ".join(sorted(missing_libraries)) + "\n")
+            log.write("missing dependencies:" + "\n")
+            log.write(" ".join(sorted(missing_libraries)) + "\n")
         else:
             touch("success")
 
@@ -64,10 +70,9 @@ def plugin_loaded():
 
     # restart sublime when `sublime.error_message` is run
     def error_message(message):
-        with open(logfile, "a") as f:
-            f.write(message + "\n")
-
+        log.write(message + "\n")
         kill_subl(True)
 
     sublime.error_message = error_message
-    sublime.set_timeout(satisfy_libraries, 10000)
+    sublime.message_dialog = error_message
+    sublime.set_timeout(satisfy_libraries, 5000)

--- a/sbin/run_scheduler.py
+++ b/sbin/run_scheduler.py
@@ -1,3 +1,29 @@
+import os
+import sublime
+import sys
+
 from .unittesting import run_scheduler
 
-run_scheduler()
+log = open(
+    os.path.join(os.path.dirname(__file__), "unittesting.log"),
+    "a",
+    encoding="utf-8",
+    buffering=1,
+)
+
+# redirect ST console output to a logfile
+sys.stdout = log
+sys.stderr = log
+
+
+def error_message(message):
+    print(message)
+
+
+# redirect ST error and message boxes to console only
+sublime.error_message = error_message
+sublime.message_dialog = error_message
+
+
+def plugin_loaded():
+    run_scheduler()

--- a/scripts/install_package_control.ps1
+++ b/scripts/install_package_control.ps1
@@ -33,6 +33,9 @@ Copy-Item "$BASE\install_package_control_helper.py" "$PCH_PATH\install_package_c
 Copy-Item "$BASE\.python-version" "$PCH_PATH\.python-version"
 
 for ($i=1; $i -le 3; $i++) {
+    if (test-path "$PCH_PATH\success") {
+        remove-item "$PCH_PATH\success" -Force
+    }
 
     & "C:\st\sublime_text.exe"
     $startTime = get-date

--- a/scripts/install_package_control.sh
+++ b/scripts/install_package_control.sh
@@ -67,6 +67,8 @@ fi
 # launch sublime text in background
 echo Starting Sublime Text
 for i in {1..3}; do
+    rm -f "$PCH_PATH/success"
+
     subl &
 
     ENDTIME=$(( $(date +%s) + 60 ))
@@ -80,6 +82,13 @@ for i in {1..3}; do
     sleep 4
     [ -f "$PCH_PATH/success" ] && break
 done
+
+echo "" # add newline after progress dots
+echo Terminated Sublime Text
+
+if [ -f "$PCH_PATH/log" ]; then
+    cat "$PCH_PATH/log"
+fi
 
 if [ ! -f "$PCH_PATH/success" ]; then
     if [ -f "$PCH_PATH/log" ]; then

--- a/scripts/install_package_control_helper.py
+++ b/scripts/install_package_control_helper.py
@@ -15,6 +15,8 @@ def plugin_loaded():
     sys.stderr = log
 
     def kill_subl(restart=False):
+        log.close()
+
         if sublime.platform() == "osx":
             cmd = "sleep 1; pkill [Ss]ubl; pkill plugin_host; sleep 1; "
             if restart:
@@ -51,7 +53,10 @@ def plugin_loaded():
 
         # query and install missing libraries
         required_libraries = manager.find_required_libraries()
-        if required_libraries:
+        missing_libraries = manager.find_missing_libraries(
+            required_libraries=required_libraries
+        )
+        if missing_libraries:
             manager.install_libraries(required_libraries, fail_early=False)
 
         # re-query missing libraries
@@ -68,8 +73,9 @@ def plugin_loaded():
 
     # restart sublime when `sublime.error_message` is run
     def error_message(message):
-        # log.write(message + "\n")
+        log.write(message + "\n")
         kill_subl(True)
 
     sublime.error_message = error_message
-    sublime.set_timeout(satisfy_libraries, 5000)
+    sublime.message_dialog = error_message
+    sublime.set_timeout(satisfy_libraries, 10000)

--- a/scripts/install_package_control_helper.py
+++ b/scripts/install_package_control_helper.py
@@ -78,4 +78,4 @@ def plugin_loaded():
 
     sublime.error_message = error_message
     sublime.message_dialog = error_message
-    sublime.set_timeout(satisfy_libraries, 10000)
+    sublime.set_timeout(satisfy_libraries, 5000)

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -1,3 +1,29 @@
+import os
+import sublime
+import sys
+
 from .unittesting import run_scheduler
 
-run_scheduler()
+log = open(
+    os.path.join(os.path.dirname(__file__), "unittesting.log"),
+    "a",
+    encoding="utf-8",
+    buffering=1,
+)
+
+# redirect ST console output to a logfile
+sys.stdout = log
+sys.stderr = log
+
+
+def error_message(message):
+    print(message)
+
+
+# redirect ST error and message boxes to console only
+sublime.error_message = error_message
+sublime.message_dialog = error_message
+
+
+def plugin_loaded():
+    run_scheduler()

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -174,13 +174,15 @@ def read_output(path, timeout=5 * 60):
     return success
 
 
-def restore_coverage_file(path, package):
-    # restore .coverage if it exists, needed for coveralls
-    if os.path.exists(path):
-        with open(path, 'r') as f:
+def restore_coverage_report(report_file):
+    # restore coverage.xml if it exists, needed for coveralls
+    if os.path.isfile(report_file):
+        source_path, name = os.path.splitext(report_file)
+        dest_path = os.getcwd()
+        with open(report_file, 'r') as f:
             txt = f.read()
-        txt = txt.replace(os.path.realpath(os.path.join(PACKAGES_DIR_PATH, package)), os.getcwd())
-        with open(os.path.join(os.getcwd(), ".coverage"), "w") as f:
+        txt = txt.replace(source_path, dest_path)
+        with open(os.path.join(dest_path, name), "w") as f:
             f.write(txt)
 
 
@@ -189,6 +191,7 @@ def main(default_schedule_info):
     output_dir = os.path.join(UT_OUTPUT_DIR_PATH, package_under_test)
     output_file = os.path.join(output_dir, "result")
     coverage_file = os.path.join(output_dir, "coverage")
+    report_file = os.path.join(PACKAGES_DIR_PATH, package_under_test, "coverage.xml")
 
     default_schedule_info['output'] = output_file
 
@@ -196,6 +199,7 @@ def main(default_schedule_info):
         create_dir_if_not_exists(output_dir)
         delete_file_if_exists(output_file)
         delete_file_if_exists(coverage_file)
+        delete_file_if_exists(report_file)
         create_schedule(package_under_test, output_file, default_schedule_info)
         delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
         copy_file_if_not_exists(SCHEDULE_RUNNER_SOURCE, SCHEDULE_RUNNER_TARGET)
@@ -222,7 +226,7 @@ def main(default_schedule_info):
         print("Timeout: output is frozen.")
         delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
         sys.exit(1)
-    restore_coverage_file(coverage_file, package_under_test)
+    restore_coverage_report(report_file)
     delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
 
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -19,16 +19,24 @@ import threading
 
 # todo: allow different sublime versions
 
-PACKAGES_DIR_PATH = os.environ.get("SUBLIME_TEXT_PACKAGES", os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..')))
-UT_OUTPUT_DIR_PATH = os.path.realpath(os.path.join(PACKAGES_DIR_PATH, 'User', 'UnitTesting'))
-SCHEDULE_FILE_PATH = os.path.realpath(os.path.join(UT_OUTPUT_DIR_PATH, 'schedule.json'))
-UT_DIR_PATH = os.path.realpath(os.path.join(PACKAGES_DIR_PATH, 'UnitTesting'))
-SCHEDULE_RUNNER_SOURCE = os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__))), "run_scheduler.py")
+PACKAGES_DIR_PATH = os.path.realpath(
+    os.environ.get(
+        "SUBLIME_TEXT_PACKAGES", os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+)
+UT_OUTPUT_DIR_PATH = os.path.realpath(
+    os.path.join(PACKAGES_DIR_PATH, "User", "UnitTesting")
+)
+SCHEDULE_FILE_PATH = os.path.realpath(os.path.join(UT_OUTPUT_DIR_PATH, "schedule.json"))
+UT_DIR_PATH = os.path.realpath(os.path.join(PACKAGES_DIR_PATH, "UnitTesting"))
+SCHEDULE_RUNNER_SOURCE = os.path.join(
+    os.path.realpath(os.path.join(os.path.dirname(__file__))), "run_scheduler.py"
+)
 SCHEDULE_RUNNER_TARGET = os.path.join(UT_DIR_PATH, "zzz_run_scheduler.py")
-RX_RESULT = re.compile(r'^(?P<result>OK|FAILED|ERROR)', re.MULTILINE)
-RX_DONE = re.compile(r'^UnitTesting: Done\.$', re.MULTILINE)
+RX_RESULT = re.compile(r"^(?P<result>OK|FAILED|ERROR)", re.MULTILINE)
+RX_DONE = re.compile(r"^UnitTesting: Done\.$", re.MULTILINE)
 
-_is_windows = sys.platform == 'win32'
+_is_windows = sys.platform == "win32"
 
 
 def create_dir_if_not_exists(path):
@@ -50,15 +58,15 @@ def create_schedule(package, output_file, default_schedule):
     schedule = []
 
     try:
-        with open(SCHEDULE_FILE_PATH, 'r') as f:
+        with open(SCHEDULE_FILE_PATH, "r") as f:
             schedule = json.load(f)
     except Exception:
         pass
 
-    if not any(s['package'] == package for s in schedule):
+    if not any(s["package"] == package for s in schedule):
         schedule.append(default_schedule)
 
-    with open(SCHEDULE_FILE_PATH, 'w') as f:
+    with open(SCHEDULE_FILE_PATH, "w") as f:
         f.write(json.dumps(schedule, ensure_ascii=False, indent=True))
 
 
@@ -83,7 +91,7 @@ def wait_for_output(path, schedule, timeout=30):
         if check_has_timed_out():
             print()
             delete_file_if_exists(schedule)
-            raise ValueError('timeout')
+            raise ValueError("timeout")
 
         time.sleep(1)
     else:
@@ -100,13 +108,15 @@ def start_sublime_text():
 
 def kill_sublime_text():
     if _is_windows:
-        subprocess.Popen([
-            "pwsh",
-            "-command",
-            "stop-process -force -processname sublime_text -ea silentlycontinue"])
+        subprocess.Popen(
+            [
+                "pwsh",
+                "-command",
+                "stop-process -force -processname sublime_text -ea silentlycontinue",
+            ]
+        )
     else:
-        subprocess.Popen("pkill [Ss]ubl || true", shell=True)
-        subprocess.Popen("pkill plugin_host || true", shell=True)
+        subprocess.Popen("pkill [Ss]ubl || true; pkill plugin_host || true", shell=True)
 
 
 def read_output(path, timeout=5 * 60):
@@ -118,14 +128,14 @@ def read_output(path, timeout=5 * 60):
 
     def check_is_success(result):
         try:
-            return RX_RESULT.search(result).group('result') == 'OK'
+            return RX_RESULT.search(result).group("result") == "OK"
         except AttributeError:
             return success
 
     lock = threading.Lock()
 
     def reader():
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             while not done:
                 offset = f.tell()
                 line = f.readline()
@@ -168,7 +178,7 @@ def read_output(path, timeout=5 * 60):
 
         if RX_DONE.search(line) is not None:
             done = True
-            assert success is not None, 'Cannot determine test results.'
+            assert success is not None, "Cannot determine test results."
             break
 
     return success
@@ -176,24 +186,30 @@ def read_output(path, timeout=5 * 60):
 
 def restore_coverage_report(report_file):
     # restore coverage.xml if it exists, needed for coveralls
-    if os.path.isfile(report_file):
-        source_path, name = os.path.splitext(report_file)
-        dest_path = os.getcwd()
-        with open(report_file, 'r') as f:
-            txt = f.read()
-        txt = txt.replace(source_path, dest_path)
-        with open(os.path.join(dest_path, name), "w") as f:
-            f.write(txt)
+    if not os.path.isfile(report_file):
+        print("UnitTesting: Skipped coverage report.")
+        return
+
+    source_path, name = os.path.split(report_file)
+    dest_path = os.getcwd()
+    dest_file = os.path.join(dest_path, name)
+    with open(report_file, "r") as f:
+        txt = f.read()
+    txt = txt.replace(source_path, dest_path)
+    with open(dest_file, "w") as f:
+        f.write(txt)
+    print(f"UnitTesting: Restored {dest_file}")
 
 
 def main(default_schedule_info):
-    package_under_test = default_schedule_info['package']
+    package_under_test = default_schedule_info["package"]
     output_dir = os.path.join(UT_OUTPUT_DIR_PATH, package_under_test)
     output_file = os.path.join(output_dir, "result")
     coverage_file = os.path.join(output_dir, "coverage")
     report_file = os.path.join(PACKAGES_DIR_PATH, package_under_test, "coverage.xml")
+    log_file = os.path.join(PACKAGES_DIR_PATH, package_under_test, "unittesting.log")
 
-    default_schedule_info['output'] = output_file
+    default_schedule_info["output"] = output_file
 
     for i in range(3):
         create_dir_if_not_exists(output_dir)
@@ -211,12 +227,22 @@ def main(default_schedule_info):
         except ValueError:
             if i == 2:
                 print("Timeout: Could not obtain tests output.")
-                print("Maybe Sublime Text is not responding or the tests output "
-                      "is being written to the wrong file.")
+                print(
+                    "Maybe Sublime Text is not responding or the tests output "
+                    "is being written to the wrong file."
+                )
                 delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
+
+                # print errors recorded by ST
+                if os.path.isfile(log_file):
+                    with open(log_file) as f:
+                        print(f.read())
+
+                kill_sublime_text()
                 sys.exit(1)
-            kill_sublime_text()
-            time.sleep(2)
+            else:
+                kill_sublime_text()
+                time.sleep(2)
 
     print("Start to read output...")
     try:
@@ -225,17 +251,20 @@ def main(default_schedule_info):
     except TimeoutError:
         print("Timeout: output is frozen.")
         delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
+        kill_sublime_text()
         sys.exit(1)
-    restore_coverage_report(report_file)
-    delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
+    else:
+        restore_coverage_report(report_file)
+        delete_file_if_exists(SCHEDULE_RUNNER_TARGET)
+        kill_sublime_text()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = optparse.OptionParser()
-    parser.add_option('--syntax-test', action='store_true')
-    parser.add_option('--syntax-compatibility', action='store_true')
-    parser.add_option('--color-scheme-test', action='store_true')
-    parser.add_option('--coverage', action='store_true')
+    parser.add_option("--syntax-test", action="store_true")
+    parser.add_option("--syntax-compatibility", action="store_true")
+    parser.add_option("--color-scheme-test", action="store_true")
+    parser.add_option("--coverage", action="store_true")
 
     options, remainder = parser.parse_args()
 
@@ -246,11 +275,11 @@ if __name__ == '__main__':
     package_under_test = remainder[0] if len(remainder) > 0 else "UnitTesting"
 
     default_schedule_info = {
-        'package': package_under_test,
-        'syntax_test': syntax_test,
-        'syntax_compatibility': syntax_compatibility,
-        'color_scheme_test': color_scheme_test,
-        'coverage': coverage,
+        "package": package_under_test,
+        "syntax_test": syntax_test,
+        "syntax_compatibility": syntax_compatibility,
+        "color_scheme_test": color_scheme_test,
+        "coverage": coverage,
     }
 
     main(default_schedule_info)

--- a/unittesting/coverage.py
+++ b/unittesting/coverage.py
@@ -21,13 +21,16 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
             stream.write("Warning: coverage cannot be loaded.\n\n")
             super().unit_testing(stream, package, settings, [])
             return
+        elif sys.version_info >= (3, 8) and sys.platform == "darwin":
+            # https://github.com/SublimeText/UnitTesting/issues/234
+            stream.write("Warning: coverage not compatible with ST4 on MacOS.\n\n")
+            super().unit_testing(stream, package, settings, [])
+            return
 
         package_path = os.path.join(sublime.packages_path(), package)
-        data_file = os.path.join(
-            sublime.packages_path(), "User", "UnitTesting", package, "coverage")
-        data_file_dir = os.path.dirname(data_file)
-        if not os.path.isdir(data_file_dir):
-            os.makedirs(data_file_dir)
+        data_file_dir = os.path.join(sublime.packages_path(), "User", "UnitTesting", package)
+        os.makedirs(data_file_dir, exist_ok=True)
+        data_file = os.path.join(data_file_dir, "coverage")
         if os.path.exists(data_file):
             os.unlink(data_file)
         config_file = os.path.join(package_path, ".coveragerc")

--- a/unittesting/coverage.py
+++ b/unittesting/coverage.py
@@ -17,6 +17,11 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
     fallback33 = "unit_testing33_coverage"
 
     def unit_testing(self, stream, package, settings):
+        if not coverage_loaded:
+            stream.write("Warning: coverage cannot be loaded.\n\n")
+            super().unit_testing(stream, package, settings, [])
+            return
+
         package_path = os.path.join(sublime.packages_path(), package)
         data_file = os.path.join(
             sublime.packages_path(), "User", "UnitTesting", package, "coverage")
@@ -38,46 +43,43 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
         else:
             config_file = None
 
-        if coverage_loaded:
-            cov = coverage.Coverage(
-                data_file=data_file, config_file=config_file, include=include, omit=omit)
+        cov = coverage.Coverage(
+            data_file=data_file, config_file=config_file, include=include, omit=omit)
 
-            if not settings['start_coverage_after_reload']:
-                cov.start()
-            if settings["reload_package_on_testing"]:
-                self.reload_package(package, dummy=False, show_reload_progress=False)
-            if settings['start_coverage_after_reload']:
-                cov.start()
+        if not settings['start_coverage_after_reload']:
+            cov.start()
+        if settings["reload_package_on_testing"]:
+            self.reload_package(package, dummy=False, show_reload_progress=False)
+        if settings['start_coverage_after_reload']:
+            cov.start()
 
+        if settings['coverage_on_worker_thread']:
+            import threading
+            original_set_timeout_async = sublime.set_timeout_async
+
+            def set_timeout_async(callback, *args, **kwargs):
+
+                def _():
+                    sys.settrace(threading._trace_hook)
+                    callback()
+
+                original_set_timeout_async(_, *args, **kwargs)
+
+            sublime.set_timeout_async = set_timeout_async
+
+        def cleanup():
             if settings['coverage_on_worker_thread']:
-                import threading
-                original_set_timeout_async = sublime.set_timeout_async
+                sublime.set_timeout_async = original_set_timeout_async
 
-                def set_timeout_async(callback, *args, **kwargs):
+            stream.write("\n")
+            cov.stop()
+            coverage.files.RELATIVE_DIR = os.path.normcase(package_path + os.sep)
+            ignore_errors = cov.get_option("report:ignore_errors")
+            show_missing = cov.get_option("report:show_missing")
+            cov.report(file=stream, ignore_errors=ignore_errors, show_missing=show_missing)
+            if settings['generate_html_report']:
+                html_output_dir = os.path.join(package_path, 'htmlcov')
+                cov.html_report(directory=html_output_dir, ignore_errors=ignore_errors)
+            cov.save()
 
-                    def _():
-                        sys.settrace(threading._trace_hook)
-                        callback()
-
-                    original_set_timeout_async(_, *args, **kwargs)
-
-                sublime.set_timeout_async = set_timeout_async
-
-            def cleanup():
-                if settings['coverage_on_worker_thread']:
-                    sublime.set_timeout_async = original_set_timeout_async
-
-                stream.write("\n")
-                cov.stop()
-                coverage.files.RELATIVE_DIR = os.path.normcase(package_path + os.sep)
-                ignore_errors = cov.get_option("report:ignore_errors")
-                show_missing = cov.get_option("report:show_missing")
-                cov.report(file=stream, ignore_errors=ignore_errors, show_missing=show_missing)
-                if settings['generate_html_report']:
-                    html_output_dir = os.path.join(package_path, 'htmlcov')
-                    cov.html_report(directory=html_output_dir, ignore_errors=ignore_errors)
-                cov.save()
-            super().unit_testing(stream, package, settings, [cleanup])
-        else:
-            stream.write("Warning: coverage cannot be loaded.\n\n")
-            super().unit_testing(stream, package, settings, [])
+        super().unit_testing(stream, package, settings, [cleanup])

--- a/unittesting/coverage.py
+++ b/unittesting/coverage.py
@@ -77,9 +77,15 @@ class UnitTestingCoverageCommand(UnitTestingCommand):
             ignore_errors = cov.get_option("report:ignore_errors")
             show_missing = cov.get_option("report:show_missing")
             cov.report(file=stream, ignore_errors=ignore_errors, show_missing=show_missing)
+
+            if settings['generate_xml_report']:
+                xml_report_file = os.path.join(package_path, 'coverage.xml')
+                cov.xml_report(outfile=xml_report_file, ignore_errors=ignore_errors)
+
             if settings['generate_html_report']:
                 html_output_dir = os.path.join(package_path, 'htmlcov')
                 cov.html_report(directory=html_output_dir, ignore_errors=ignore_errors)
+
             cov.save()
 
         super().unit_testing(stream, package, settings, [cleanup])

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -25,6 +25,7 @@ DEFAULT_SETTINGS = {
     "start_coverage_after_reload": False,
     "coverage_on_worker_thread": False,  # experimental
     "generate_html_report": False,
+    "generate_xml_report": False,
     "capture_console": False,
     "failfast": False,
     "condition_timeout": 4000,

--- a/unittesting/scheduler.py
+++ b/unittesting/scheduler.py
@@ -36,7 +36,8 @@ class Unit:
         elif self.coverage:
             sublime.run_command("unit_testing_coverage", {
                 "package": self.package,
-                "output": self.output
+                "output": self.output,
+                "generate_xml_report": True
             })
         else:
             sublime.run_command("unit_testing", {


### PR DESCRIPTION
This PR...

1. tweaks install helpers to remove possible `success` file before starting ST
2. redirects ST console output to Github Actions in case of run-tests not detecting any test output. It was required to find #234.
3. teaches UnitTesting to directly create coverage.xml instead of setting up and running a dedicated task for conversion. This was required as coverage dataformat changed between v4.5 and 7.x. It's a sqlite database now.
4. Skips coverage on python 3.8 on MacOS, because of #234.