### PR TITLE
Optimize unittest scheduler

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -20,7 +20,6 @@ from . import unittesting
 sys.modules["unittesting"] = unittesting
 
 
-from unittesting import UnitTestingRunSchedulerCommand
 from unittesting import UnitTestingCommand
 from unittesting import UnitTestingCoverageCommand
 from unittesting import UnitTestingCurrentFileCommand
@@ -32,7 +31,6 @@ from unittesting import UnitTestingColorSchemeCommand
 
 
 __all__ = [
-    "UnitTestingRunSchedulerCommand",
     "UnitTestingCommand",
     "UnitTestingCoverageCommand",
     "UnitTestingCurrentFileCommand",

--- a/sbin/run_scheduler.py
+++ b/sbin/run_scheduler.py
@@ -1,3 +1,11 @@
+"""
+Schedule runner plugin.
+
+This module ...
+1. is copied to $st_data/Packages/UnitTesting/run_scheduler.py
+2. loaded as Sublime Text plugin
+3. invokes scheduled package tests
+"""
 import os
 import sublime
 import sys

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -1,3 +1,11 @@
+"""
+Schedule runner plugin.
+
+This module ...
+1. is copied to $st_data/Packages/UnitTesting/run_scheduler.py
+2. loaded as Sublime Text plugin
+3. invokes scheduled package tests
+"""
 import os
 import sublime
 import sys

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,5 +1,4 @@
 from .core import DeferrableTestCase, AWAIT_WORKER, expectedFailure
-from .scheduler import UnitTestingRunSchedulerCommand
 from .scheduler import run_scheduler
 from .package import UnitTestingCommand
 from .coverage import UnitTestingCoverageCommand
@@ -13,7 +12,6 @@ from .color_scheme import UnitTestingColorSchemeCommand
 
 __all__ = [
     "DeferrableTestCase",
-    "UnitTestingRunSchedulerCommand",
     "run_scheduler",
     "UnitTestingCommand",
     "UnitTestingCoverageCommand",

--- a/unittesting/scheduler.py
+++ b/unittesting/scheduler.py
@@ -1,8 +1,6 @@
 import os
-import threading
-import time
 import sublime
-import sublime_plugin
+
 from .utils import JsonFile
 
 
@@ -71,24 +69,6 @@ class Scheduler:
         self.j.save([])
 
 
-class UnitTestingRunSchedulerCommand(sublime_plugin.ApplicationCommand):
-    ready = False
-
-    def run(self):
-        UnitTestingRunSchedulerCommand.ready = True
-        scheduler = Scheduler()
-        sublime.set_timeout(scheduler.run, 2000)
-
-
-def try_running_scheduler():
-    while not UnitTestingRunSchedulerCommand.ready:
-        sublime.set_timeout(
-            lambda: sublime.run_command("unit_testing_run_scheduler"), 1)
-
-        time.sleep(1)
-
-
 def run_scheduler():
-    UnitTestingRunSchedulerCommand.ready = False
-    th = threading.Thread(target=try_running_scheduler)
-    th.start()
+    # delay schedule initialization and execution
+    sublime.set_timeout(lambda: Scheduler().run(), 2000)


### PR DESCRIPTION
Due to use of `plugin_loaded()`, scheduler is invoked after all plugins have been loaded. No need to poll.