### PR TITLE
Simplify reloader

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -15,7 +15,8 @@ for module_name in [
     del sys.modules[module_name]
 prefix = None
 
-from . import unittesting
+import UnitTesting
+from UnitTesting import unittesting
 
 sys.modules["unittesting"] = unittesting
 

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,4 +1,6 @@
 // do not copy
 {
     "coverage_on_worker_thread": true,
+	"reload_package_on_testing": false,
+	"show_reload_progress": false,
 }


### PR DESCRIPTION
This commit simplifies GitSavvy's reloader from PR #229 by removing intercepting reloading, because it destroys a reloaded package's namespace module by clearing its `__path__` or `__spec__.module_search_locations`.

As a result it was no longer possible to import modules from sub directories, which caused test modules not to be importable any more.

Thus `"reload_package_on_testing": true` caused all test cases to be vanished.

Actually it should be enough to remove all modules from sys.modules and re-import all top-level plugins in order for all required once to be re-imported in correct order as well.