### PR TITLE
Improve Package Control installer scripts

### DIFF
--- a/scripts/install_package_control.sh
+++ b/scripts/install_package_control.sh
@@ -43,12 +43,13 @@ fi
 
 PC_PATH="$STIP/Package Control.sublime-package"
 if [ ! -f "$PC_PATH" ]; then
+    echo Downloading Package Control.sublime-package
     PC_URL="https://github.com/wbond/package_control/releases/latest/download/Package.Control.sublime-package"
     curl -s -L "$PC_URL" -o "$PC_PATH"
 fi
 
 if [ ! -f "$STP/User/Package Control.sublime-settings" ]; then
-    echo creating Package Control.sublime-settings
+    echo Creating Package Control.sublime-settings
     [ ! -d "$STP/User" ] && mkdir -p "$STP/User"
     # make sure Pakcage Control does not complain
     echo '{"auto_upgrade": false, "ignore_vcs_packages": true, "remove_orphaned": false, "submit_usage": false }' > "$STP/User/Package Control.sublime-settings"
@@ -63,23 +64,23 @@ if [ ! -d "$PCH_PATH" ]; then
     cp "$BASE/.python-version" "$PCH_PATH/.python-version"
 fi
 
-
 # launch sublime text in background
 echo Starting Sublime Text
-for i in {1..3}; do
-    rm -f "$PCH_PATH/success"
 
+for i in {1..3}; do
     subl &
 
     ENDTIME=$(( $(date +%s) + 60 ))
-    while [ ! -f "$PCH_PATH/success" ] && [ $(date +%s) -lt $ENDTIME ]  ; do
+    while [ ! -f "$PCH_PATH/failed" ] && [ ! -f "$PCH_PATH/success" ] && [ $(date +%s) -lt $ENDTIME ] ; do
         printf "."
         sleep 5
     done
 
-    pkill "[Ss]ubl" || true
-    pkill 'plugin_host' || true
-    sleep 4
+    sleep 2
+    pkill subl || true
+    sleep 2
+
+    [ -f "$PCH_PATH/failed" ] && break
     [ -f "$PCH_PATH/success" ] && break
 done
 
@@ -91,15 +92,11 @@ if [ -f "$PCH_PATH/log" ]; then
 fi
 
 if [ ! -f "$PCH_PATH/success" ]; then
-    if [ -f "$PCH_PATH/log" ]; then
-        cat "$PCH_PATH/log"
-    fi
     echo "Timeout: Fail to install Package Control."
     rm -rf "$PCH_PATH"
     exit 1
 fi
 
 rm -rf "$PCH_PATH"
-echo ""
 
 echo "Package Control installed."

--- a/scripts/install_package_control_helper.py
+++ b/scripts/install_package_control_helper.py
@@ -5,9 +5,9 @@ import sys
 
 
 def plugin_loaded():
-    logfile = os.path.join(
-        sublime.packages_path(), "0_install_package_control_helper", "log"
-    )
+    package_path = os.path.join(sublime.packages_path(), "0_install_package_control_helper")
+
+    logfile = os.path.join(package_path, "log")
 
     log = open(logfile, "a", encoding="utf-8")
 
@@ -18,64 +18,71 @@ def plugin_loaded():
         log.close()
 
         if sublime.platform() == "osx":
-            cmd = "sleep 1; pkill [Ss]ubl; pkill plugin_host; sleep 1; "
+            cmd = "pkill subl"
             if restart:
-                cmd = (
-                    cmd + "osascript -e 'tell application \"Sublime Text\" to activate'"
-                )
+                cmd += "; sleep 1; subl'"
         elif sublime.platform() == "linux":
-            cmd = "sleep 1; pkill [Ss]ubl; pkill plugin_host; sleep 1; "
+            cmd = "pkill subl"
             if restart:
-                cmd = cmd + "subl"
+                cmd += "; sleep 1; subl"
         elif sublime.platform() == "windows":
-            cmd = "sleep 1 & taskkill /F /im sublime_text.exe & sleep 1 "
+            cmd = "taskkill /F /im sublime_text.exe"
             if restart:
-                cmd = cmd + '& "{}"'.format(sublime.executable_path())
+                cmd += ' & sleep 1 & "{}"'.format(sublime.executable_path())
         else:
             return
 
         subprocess.Popen(cmd, shell=True)
 
     def touch(file_name):
-        f = os.path.join(
-            sublime.packages_path(), "0_install_package_control_helper", file_name
-        )
-        open(f, "a").close()
+        open(os.path.join(package_path, file_name), "a").close()
 
-    def satisfy_libraries():
+    def check_package_control():
+        """
+        Wait for Package Control to be loaded.
+        """
         if "Package Control" in sys.modules:
-            package_control = sys.modules["Package Control"].package_control
+            sublime.set_timeout(check_libraries, 2000)
         else:
-            sublime.set_timeout(satisfy_libraries, 5000)
-            return
+            sublime.set_timeout(check_package_control, 2000)
 
+    num_retries = 0
+
+    def check_libraries():
+        """
+        Wait for Package Control to finish bootstrapping.
+
+        PC4 automatically installs missing libraries at startup
+        just need to wait for it being completed.
+        """
+        package_control = sys.modules["Package Control"].package_control
         manager = package_control.package_manager.PackageManager()
-
-        # query and install missing libraries
-        required_libraries = manager.find_required_libraries()
-        missing_libraries = manager.find_missing_libraries(
-            required_libraries=required_libraries
-        )
+        missing_libraries = manager.find_missing_libraries()
         if missing_libraries:
-            manager.install_libraries(required_libraries, fail_early=False)
+            nonlocal num_retries
 
-        # re-query missing libraries
-        missing_libraries = manager.find_missing_libraries(
-            required_libraries=required_libraries
-        )
-        if missing_libraries:
-            log.write("missing dependencies:" + "\n")
+            if num_retries < 3:
+                num_retries += 1
+                sublime.set_timeout(check_libraries, 2000)
+                return
+
+            log.write("missing libraries:" + "\n")
             log.write(" ".join(sorted(missing_libraries)) + "\n")
+            touch("failed")
         else:
             touch("success")
 
-        kill_subl()
+        kill_subl(restart=False)
 
-    # restart sublime when `sublime.error_message` is run
     def error_message(message):
+        """Restart sublime when `sublime.error_message()` is run."""
         log.write(message + "\n")
-        kill_subl(True)
+        kill_subl(restart=True)
+
+    def info_message(message):
+        """Print output from `sublime.message_dialog()` to logfile."""
+        log.write(message + "\n")
 
     sublime.error_message = error_message
-    sublime.message_dialog = error_message
-    sublime.set_timeout(satisfy_libraries, 5000)
+    sublime.message_dialog = info_message
+    sublime.set_timeout(check_package_control, 2000)


### PR DESCRIPTION
This PR ...

1. applies some code style changes to package control installer powershell scripts
2. adds some logging messages about progress
3. simplifies task killing (`pkill subl`, dropping `pkill plugin_host`)  because the former also kills all sub-processes, which includes plugin_host.
4. Tweaks install_helper plugin to avoid concurrent tries to install dependencies. Package Control 4 automatically installs all missing libraries at startup. The install_helper, just needs to wait for completion before terminating ST again.

This speeds setting ST & PC up on MacOS runners, significantly.