### PR TITLE
Fix calling stopTestRun directly at start

### DIFF
--- a/unittesting/core/py38/runner.py
+++ b/unittesting/core/py38/runner.py
@@ -54,10 +54,6 @@ class DeferringTextTestRunner(TextTestRunner):
                     _continue_testing(deferred)
                 except Exception as e:
                     _handle_error(e)
-                finally:
-                    stopTestRun = getattr(result, 'stopTestRun', None)
-                    if stopTestRun is not None:
-                        stopTestRun()
 
         def _continue_testing(deferred, send_value=None, throw_value=None):
             try:


### PR DESCRIPTION
The removed code block caused `stopTestRun()` callback being executed directly after starting a test run.

This regression was introduced in py38 runner, only.