### PR TITLE
Refactor condition_timeout default value handling

### DIFF
--- a/unittesting/core/py33/runner.py
+++ b/unittesting/core/py33/runner.py
@@ -20,7 +20,21 @@ run_on_worker = sublime.set_timeout_async
 
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
-    condition_timeout = DEFAULT_CONDITION_TIMEOUT
+
+    def __init__(
+        self,
+        stream=None,
+        descriptions=True,
+        verbosity=1,
+        failfast=False,
+        buffer=False,
+        resultclass=None,
+        warnings=None,
+        condition_timeout=DEFAULT_CONDITION_TIMEOUT,
+    ):
+        super(DeferringTextTestRunner, self).__init__(
+            stream, descriptions, verbosity, failfast, buffer, resultclass, warnings)
+        self.condition_timeout = condition_timeout
 
     def run(self, test):
         """Run the given test case or test suite."""
@@ -88,10 +102,9 @@ class DeferringTextTestRunner(TextTestRunner):
         def _wait_condition(
             deferred, condition,
             period=DEFAULT_CONDITION_POLL_TIME,
-            timeout=None,
+            timeout=self.condition_timeout,
             start_time=None
         ):
-            timeout = timeout or self.condition_timeout
             if start_time is None:
                 start_time = time.time()
 

--- a/unittesting/core/py38/runner.py
+++ b/unittesting/core/py38/runner.py
@@ -20,7 +20,23 @@ run_on_worker = sublime.set_timeout_async
 
 class DeferringTextTestRunner(TextTestRunner):
     """This test runner runs tests in deferred slices."""
-    condition_timeout = DEFAULT_CONDITION_TIMEOUT
+
+    def __init__(
+        self,
+        stream=None,
+        descriptions=True,
+        verbosity=1,
+        failfast=False,
+        buffer=False,
+        resultclass=None,
+        warnings=None,
+        *,
+        condition_timeout=DEFAULT_CONDITION_TIMEOUT,
+        **kwargs
+    ):
+        super(DeferringTextTestRunner, self).__init__(
+            stream, descriptions, verbosity, failfast, buffer, resultclass, warnings, **kwargs)
+        self.condition_timeout = condition_timeout
 
     def run(self, test):
         """Run the given test case or test suite."""
@@ -87,10 +103,9 @@ class DeferringTextTestRunner(TextTestRunner):
         def _wait_condition(
             deferred, condition,
             period=DEFAULT_CONDITION_POLL_TIME,
-            timeout=None,
+            timeout=self.condition_timeout,
             start_time=None
         ):
-            timeout = timeout or self.condition_timeout
             if start_time is None:
                 start_time = time.time()
 

--- a/unittesting/package.py
+++ b/unittesting/package.py
@@ -91,8 +91,11 @@ class UnitTestingCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):
                     if settings["legacy_runner"]:
                         raise Exception("`legacy_runner=True` is deprecated.")
                     testRunner = DeferringTextTestRunner(
-                        stream, verbosity=settings["verbosity"], failfast=settings['failfast'])
-                    testRunner.condition_timeout = settings["condition_timeout"]
+                        stream=stream,
+                        verbosity=settings["verbosity"],
+                        failfast=settings['failfast'],
+                        condition_timeout=settings["condition_timeout"]
+                    )
                 else:
                     self.verify_testsuite(tests)
                     testRunner = TextTestRunner(stream, verbosity=settings["verbosity"], failfast=settings['failfast'])


### PR DESCRIPTION
1. Add proper `__init__()` methods to pass `condition_timeout` argument to newly created instances.
2. Use `self.condition_timeout()` as default in `_wait_condition()` argument list.

This adds a some more lines of code but is a more compliant solution for how to handle additional parameters for inherited classes.