### PR TITLE
Expose API and hide Commands

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -15,21 +15,15 @@ for module_name in [
     del sys.modules[module_name]
 prefix = None
 
-import UnitTesting
-from UnitTesting import unittesting
-
-sys.modules["unittesting"] = unittesting
-
-
-from unittesting import UnitTestingCommand
-from unittesting import UnitTestingCoverageCommand
-from unittesting import UnitTestingCurrentFileCommand
-from unittesting import UnitTestingCurrentFileCoverageCommand
-from unittesting import UnitTestingCurrentPackageCommand
-from unittesting import UnitTestingCurrentPackageCoverageCommand
-from unittesting import UnitTestingSyntaxCommand
-from unittesting import UnitTestingSyntaxCompatibilityCommand
-from unittesting import UnitTestingColorSchemeCommand
+from .unittesting.color_scheme import UnitTestingColorSchemeCommand
+from .unittesting.coverage import UnitTestingCoverageCommand
+from .unittesting.current import UnitTestingCurrentFileCommand
+from .unittesting.current import UnitTestingCurrentFileCoverageCommand
+from .unittesting.current import UnitTestingCurrentPackageCommand
+from .unittesting.current import UnitTestingCurrentPackageCoverageCommand
+from .unittesting.package import UnitTestingCommand
+from .unittesting.syntax import UnitTestingSyntaxCommand
+from .unittesting.syntax import UnitTestingSyntaxCompatibilityCommand
 
 
 __all__ = [
@@ -43,6 +37,9 @@ __all__ = [
     "UnitTestingSyntaxCompatibilityCommand",
     "UnitTestingColorSchemeCommand",
 ]
+
+# publish unittesting module
+sys.modules["unittesting"] = sys.modules["UnitTesting"].unittesting
 
 UT33_CODE = """
 from UnitTesting import plugin as ut38  # noqa

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,4 +1,3 @@
-# API
 from .core import AWAIT_WORKER
 from .core import DeferrableTestCase
 from .core import expectedFailure
@@ -6,17 +5,6 @@ from .helpers import OverridePreferencesTestCase
 from .helpers import TempDirectoryTestCase
 from .helpers import ViewTestCase
 from .scheduler import run_scheduler
-
-# commands
-from .color_scheme import UnitTestingColorSchemeCommand
-from .coverage import UnitTestingCoverageCommand
-from .current import UnitTestingCurrentFileCommand
-from .current import UnitTestingCurrentFileCoverageCommand
-from .current import UnitTestingCurrentPackageCommand
-from .current import UnitTestingCurrentPackageCoverageCommand
-from .package import UnitTestingCommand
-from .syntax import UnitTestingSyntaxCommand
-from .syntax import UnitTestingSyntaxCompatibilityCommand
 
 
 __all__ = [
@@ -27,13 +15,4 @@ __all__ = [
     "OverridePreferencesTestCase",
     "TempDirectoryTestCase",
     "ViewTestCase",
-    "UnitTestingCommand",
-    "UnitTestingColorSchemeCommand",
-    "UnitTestingCoverageCommand",
-    "UnitTestingCurrentFileCommand",
-    "UnitTestingCurrentFileCoverageCommand",
-    "UnitTestingCurrentPackageCommand",
-    "UnitTestingCurrentPackageCoverageCommand",
-    "UnitTestingSyntaxCommand",
-    "UnitTestingSyntaxCompatibilityCommand",
 ]

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,5 +1,10 @@
 # API
-from .core import DeferrableTestCase, AWAIT_WORKER, expectedFailure
+from .core import AWAIT_WORKER
+from .core import DeferrableTestCase
+from .core import expectedFailure
+from .helpers import OverridePreferencesTestCase
+from .helpers import TempDirectoryTestCase
+from .helpers import ViewTestCase
 from .scheduler import run_scheduler
 
 # commands
@@ -19,7 +24,11 @@ __all__ = [
     "DeferrableTestCase",
     "expectedFailure",
     "run_scheduler",
+    "OverridePreferencesTestCase",
+    "TempDirectoryTestCase",
+    "ViewTestCase",
     "UnitTestingCommand",
+    "UnitTestingColorSchemeCommand",
     "UnitTestingCoverageCommand",
     "UnitTestingCurrentFileCommand",
     "UnitTestingCurrentFileCoverageCommand",
@@ -27,5 +36,4 @@ __all__ = [
     "UnitTestingCurrentPackageCoverageCommand",
     "UnitTestingSyntaxCommand",
     "UnitTestingSyntaxCompatibilityCommand",
-    "UnitTestingColorSchemeCommand",
 ]


### PR DESCRIPTION
This commit...

1. publishes test cases from helpers package directly under `unittesting`
2. hides ST command classes from `unittesting` module as they are needed for ST only.