### PR TITLE
Reorganize imports and publications

### DIFF
--- a/tests/_Async/tests/test.py
+++ b/tests/_Async/tests/test.py
@@ -1,6 +1,7 @@
 import sublime
-from unittest import TestCase
 import time
+
+from unittest import TestCase
 
 
 class TestAsync(TestCase):

--- a/tests/_Deferred/tests/test.py
+++ b/tests/_Deferred/tests/test.py
@@ -1,4 +1,5 @@
-from unittesting import DeferrableViewTestCase, expectedFailure
+from unittesting import DeferrableViewTestCase
+from unittesting import expectedFailure
 
 
 class TestDeferrable(DeferrableViewTestCase):

--- a/tests/test_await_worker.py
+++ b/tests/test_await_worker.py
@@ -1,9 +1,9 @@
-from functools import partial
+import sublime
 import time
 
-import sublime
-
-from unittesting import DeferrableTestCase, AWAIT_WORKER
+from functools import partial
+from unittesting import AWAIT_WORKER
+from unittesting import DeferrableTestCase
 
 
 def run_in_worker(fn, *args, **kwargs):

--- a/tests/test_deferred_timing.py
+++ b/tests/test_deferred_timing.py
@@ -1,9 +1,8 @@
-from functools import partial
-import time
-from unittest.mock import patch
-
 import sublime
+import time
 
+from functools import partial
+from unittest.mock import patch
 from unittesting import DeferrableTestCase
 
 

--- a/tests/test_expected_failures.py
+++ b/tests/test_expected_failures.py
@@ -1,15 +1,16 @@
-import sublime
+import sys
 
-try:
-    from unittest.case import _ExpectedFailure, _UnexpectedSuccess
-except ImportError:
-    pass
 from unittest import skipIf
-from unittesting import DeferrableTestCase, expectedFailure
+from unittesting import DeferrableTestCase
+from unittesting import expectedFailure
+
+PY33 = sys.version_info == (3,3)
+if PY33:
+    from unittest.case import _ExpectedFailure, _UnexpectedSuccess
 
 
 class TestExpectedFailures(DeferrableTestCase):
-    @skipIf(sublime.version() >= '4000', "Sublime Text 4 has optimization on")
+    @skipIf(not PY33, "Sublime Text 4 has optimization on")
     @expectedFailure
     def test_direct_failure1(self):
         assert False
@@ -24,7 +25,7 @@ class TestExpectedFailures(DeferrableTestCase):
             yield
             1 / 0
 
-        ex = ZeroDivisionError if sublime.version() >= "4000" else _ExpectedFailure
+        ex = _ExpectedFailure if PY33 else ZeroDivisionError
         try:
             yield from testitem()
         except ex:
@@ -37,7 +38,7 @@ class TestExpectedFailures(DeferrableTestCase):
         def testitem():
             1 / 0
 
-        ex = ZeroDivisionError if sublime.version() >= "4000" else _ExpectedFailure
+        ex = _ExpectedFailure if PY33 else ZeroDivisionError
         try:
             yield from testitem()
         except ex:
@@ -45,7 +46,7 @@ class TestExpectedFailures(DeferrableTestCase):
         else:
             self.fail('Expected _ExpectedFailure')
 
-    @skipIf(sublime.version() >= '4000', "not applicable in Python 3.8")
+    @skipIf(not PY33, "not applicable in Python 3.8")
     def test_unexpected_success_coroutine(self):
 
         @expectedFailure
@@ -59,7 +60,7 @@ class TestExpectedFailures(DeferrableTestCase):
         else:
             self.fail('Expected _UnexpectedSuccess')
 
-    @skipIf(sublime.version() >= '4000', "not applicable in Python 3.8")
+    @skipIf(not PY33, "not applicable in Python 3.8")
     def test_unexpected_success(self):
 
         @expectedFailure

--- a/unittesting/color_scheme.py
+++ b/unittesting/color_scheme.py
@@ -1,10 +1,9 @@
 import sublime
 import sublime_plugin
-
 import sys
 
-from .mixin import UnitTestingMixin
 from .const import DONE_MESSAGE
+from .mixin import UnitTestingMixin
 
 
 class UnitTestingColorSchemeCommand(sublime_plugin.ApplicationCommand, UnitTestingMixin):

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,22 +1,25 @@
 import sys
 
 if sys.version_info >= (3, 8):
-    from .py38.runner import DeferringTextTestRunner, AWAIT_WORKER
     from .py38.case import DeferrableTestCase
+    from .py38.case import expectedFailure
+    from .py38.runner import AWAIT_WORKER
+    from .py38.runner import DeferringTextTestRunner
     from .py38.suite import DeferrableTestSuite
-    from unittest import expectedFailure
 else:
-    from .py33.runner import DeferringTextTestRunner, AWAIT_WORKER
-    from .py33.case import DeferrableTestCase, expectedFailure
+    from .py33.case import DeferrableTestCase
+    from .py33.case import expectedFailure
+    from .py33.runner import AWAIT_WORKER
+    from .py33.runner import DeferringTextTestRunner
     from .py33.suite import DeferrableTestSuite
 
-from .loader import UnitTestingLoader as TestLoader  # noqa
+from .loader import UnitTestingLoader as TestLoader
 
 __all__ = [
-    "TestLoader",
-    "DeferringTextTestRunner",
+    "AWAIT_WORKER",
     "DeferrableTestCase",
     "DeferrableTestSuite",
-    "AWAIT_WORKER",
-    "expectedFailure"
+    "DeferringTextTestRunner",
+    "expectedFailure",
+    "TestLoader",
 ]

--- a/unittesting/core/loader.py
+++ b/unittesting/core/loader.py
@@ -1,5 +1,6 @@
 from unittest import TestSuite
 from unittest import TestLoader
+
 from . import DeferrableTestSuite
 
 

--- a/unittesting/core/py33/__init__.py
+++ b/unittesting/core/py33/__init__.py
@@ -1,3 +1,0 @@
-from . import case  # noqa: F401
-from . import runner  # noqa: F401
-from . import suite  # noqa: F401

--- a/unittesting/core/py33/case.py
+++ b/unittesting/core/py33/case.py
@@ -1,11 +1,20 @@
 import sys
-import unittest
 import warnings
+
 from functools import wraps
-from unittest.case import _ExpectedFailure, _UnexpectedSuccess, SkipTest, _Outcome
+from unittest import TestCase
+from unittest.case import _ExpectedFailure
+from unittest.case import _Outcome
+from unittest.case import _UnexpectedSuccess
+from unittest.case import SkipTest
 
 from ...utils import isiterable
 from .runner import defer
+
+__all__ = [
+    "DeferrableTestCase",
+    "expectedFailure"
+]
 
 
 def expectedFailure(func):
@@ -21,7 +30,7 @@ def expectedFailure(func):
     return wrapper
 
 
-class DeferrableTestCase(unittest.TestCase):
+class DeferrableTestCase(TestCase):
 
     def _executeTestPart(self, function, outcome, isTest=False):
         try:

--- a/unittesting/core/py33/runner.py
+++ b/unittesting/core/py33/runner.py
@@ -3,7 +3,8 @@ import time
 import warnings
 
 from functools import partial
-from unittest.runner import TextTestRunner, registerResult
+from unittest.runner import TextTestRunner
+from unittest.runner import registerResult
 
 DEFAULT_CONDITION_POLL_TIME = 17
 DEFAULT_CONDITION_TIMEOUT = 4000

--- a/unittesting/core/py33/suite.py
+++ b/unittesting/core/py33/suite.py
@@ -1,5 +1,9 @@
-from unittest.suite import TestSuite, _isnotsuite, _call_if_exists, _DebugResult
 from unittest import util
+from unittest.suite import _call_if_exists
+from unittest.suite import _DebugResult
+from unittest.suite import _isnotsuite
+from unittest.suite import TestSuite
+
 from ...utils import isiterable
 
 

--- a/unittesting/core/py38/__init__.py
+++ b/unittesting/core/py38/__init__.py
@@ -1,3 +1,0 @@
-from . import case  # noqa: F401
-from . import runner  # noqa: F401
-from . import suite  # noqa: F401

--- a/unittesting/core/py38/case.py
+++ b/unittesting/core/py38/case.py
@@ -1,11 +1,19 @@
 import sys
-import unittest
+
+from unittest import TestCase
 from unittest.case import _Outcome
-from .runner import defer
+from unittest.case import expectedFailure
+
 from ...utils import isiterable
+from .runner import defer
+
+__all__ = [
+    "DeferrableTestCase",
+    "expectedFailure"
+]
 
 
-class DeferrableTestCase(unittest.TestCase):
+class DeferrableTestCase(TestCase):
 
     def _callSetUp(self):
         deferred = self.setUp()

--- a/unittesting/core/py38/runner.py
+++ b/unittesting/core/py38/runner.py
@@ -3,7 +3,8 @@ import time
 import warnings
 
 from functools import partial
-from unittest.runner import TextTestRunner, registerResult
+from unittest.runner import TextTestRunner
+from unittest.runner import registerResult
 
 DEFAULT_CONDITION_POLL_TIME = 17
 DEFAULT_CONDITION_TIMEOUT = 4000

--- a/unittesting/core/py38/suite.py
+++ b/unittesting/core/py38/suite.py
@@ -1,5 +1,9 @@
-from unittest.suite import TestSuite, _isnotsuite, _call_if_exists, _DebugResult
 from unittest import util
+from unittest.suite import _call_if_exists
+from unittest.suite import _DebugResult
+from unittest.suite import _isnotsuite
+from unittest.suite import TestSuite
+
 from ...utils import isiterable
 
 

--- a/unittesting/current.py
+++ b/unittesting/current.py
@@ -3,8 +3,8 @@ import sublime
 
 from fnmatch import fnmatch
 
-from .package import UnitTestingCommand
 from .coverage import UnitTestingCoverageCommand
+from .package import UnitTestingCommand
 
 
 class UnitTestingCurrentPackageCommand(UnitTestingCommand):

--- a/unittesting/helpers/override_preferences_test_cast.py
+++ b/unittesting/helpers/override_preferences_test_cast.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import sublime
 
-from .. import DeferrableTestCase
+from ..core import DeferrableTestCase
 
 
 class OverridePreferencesTestCase(DeferrableTestCase):

--- a/unittesting/helpers/temp_directory_test_case.py
+++ b/unittesting/helpers/temp_directory_test_case.py
@@ -3,7 +3,7 @@ import shutil
 import sublime
 import tempfile
 
-from .. import DeferrableTestCase
+from ..core import DeferrableTestCase
 
 
 class TempDirectoryTestCase(DeferrableTestCase):

--- a/unittesting/helpers/view_test_case.py
+++ b/unittesting/helpers/view_test_case.py
@@ -1,7 +1,7 @@
 import sublime
 
 from unittest import TestCase
-from .. import DeferrableTestCase
+from ..core import DeferrableTestCase
 
 __all__ = [
     "DeferrableViewTestCase",

--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -6,12 +6,10 @@ import sys
 from collections import ChainMap
 from glob import glob
 
-from .utils import reload_package
-from .utils import OutputPanel
 from .utils import JsonFile
+from .utils import OutputPanel
 from .utils import ProgressBar
-
-
+from .utils import reload_package
 
 DEFAULT_SETTINGS = {
     "tests_dir": "tests",

--- a/unittesting/package.py
+++ b/unittesting/package.py
@@ -5,15 +5,14 @@ import sublime_plugin
 import sys
 import threading
 
-from unittest import TextTestRunner, TestSuite
+from unittest import TextTestRunner
+from unittest import TestSuite
 
-from .core import (
-    TestLoader,
-    DeferringTextTestRunner,
-    DeferrableTestCase
-)
-from .mixin import UnitTestingMixin
 from .const import DONE_MESSAGE
+from .core import DeferrableTestCase
+from .core import DeferringTextTestRunner
+from .core import TestLoader
+from .mixin import UnitTestingMixin
 from .utils import ProgressBar, StdioSplitter
 
 

--- a/unittesting/syntax.py
+++ b/unittesting/syntax.py
@@ -2,8 +2,8 @@ import sublime
 import sublime_api
 import sublime_plugin
 
-from .mixin import UnitTestingMixin
 from .const import DONE_MESSAGE
+from .mixin import UnitTestingMixin
 
 
 class UnitTestingSyntaxBase(sublime_plugin.ApplicationCommand, UnitTestingMixin):


### PR DESCRIPTION
This commit...

1. publishes `unittest.TestCase` as `unittesting.TestCase` for convenience.
2. imports `expectedFailure` via `core.py38.case` for API compatibility.