### PR TITLE
Refactor OutputPanel

### DIFF
--- a/unittesting/mixin.py
+++ b/unittesting/mixin.py
@@ -106,7 +106,10 @@ class UnitTestingMixin(object):
         output = settings["output"]
         if not output or output == "<panel>":
             output_panel = OutputPanel(
-                'UnitTesting', file_regex=r'File "([^"]*)", line (\d+)')
+                sublime.active_window(),
+                'exec',
+                file_regex=r'File "([^"]*)", line (\d+)'
+            )
             output_panel.show()
             stream = output_panel
         else:


### PR DESCRIPTION
1. Pass owning `window` when initializing object.
2. Replace deprecated `get_output_panel()` API call.
3. Reduce API calls when determining base_dir.
4. Use normal build output panel ("exec").
5. format code using black.