### PR TITLE
Refactor generator detection

### DIFF
--- a/tests/test_3141596.py
+++ b/tests/test_3141596.py
@@ -6,8 +6,8 @@ import sublime
 from functools import wraps
 from unittest import skipIf
 from unittesting import AWAIT_WORKER
+from unittesting import DeferrableMethod
 from unittesting import DeferrableTestCase
-from unittesting.utils import isiterable
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -83,7 +83,7 @@ def with_package(package, output=None, syntax_test=False, syntax_compatibility=F
                 txt = f.read()
 
             deferred = func(self, txt)
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
 
             yield

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,4 +1,5 @@
 from .core import AWAIT_WORKER
+from .core import DeferrableMethod
 from .core import DeferrableTestCase
 from .core import expectedFailure
 from .helpers import DeferrableViewTestCase
@@ -10,6 +11,7 @@ from .scheduler import run_scheduler
 
 __all__ = [
     "AWAIT_WORKER",
+    "DeferrableMethod",
     "DeferrableTestCase",
     "expectedFailure",
     "run_scheduler",

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,12 +1,14 @@
 import sys
 
 if sys.version_info >= (3, 8):
+    from .py38.case import DeferrableMethod
     from .py38.case import DeferrableTestCase
     from .py38.case import expectedFailure
     from .py38.runner import AWAIT_WORKER
     from .py38.runner import DeferringTextTestRunner
     from .py38.suite import DeferrableTestSuite
 else:
+    from .py33.case import DeferrableMethod
     from .py33.case import DeferrableTestCase
     from .py33.case import expectedFailure
     from .py33.runner import AWAIT_WORKER
@@ -17,6 +19,7 @@ from .loader import UnitTestingLoader as TestLoader
 
 __all__ = [
     "AWAIT_WORKER",
+    "DeferrableMethod",
     "DeferrableTestCase",
     "DeferrableTestSuite",
     "DeferringTextTestRunner",

--- a/unittesting/core/py33/case.py
+++ b/unittesting/core/py33/case.py
@@ -1,6 +1,7 @@
 import sys
 import warnings
 
+from collections.abc import Iterable as DeferrableMethod
 from functools import wraps
 from unittest import TestCase
 from unittest.case import _ExpectedFailure
@@ -8,7 +9,7 @@ from unittest.case import _Outcome
 from unittest.case import _UnexpectedSuccess
 from unittest.case import SkipTest
 
-from ...utils import isiterable
+
 from .runner import defer
 
 __all__ = [
@@ -22,7 +23,7 @@ def expectedFailure(func):
     def wrapper(*args, **kwargs):
         try:
             deferred = func(*args, **kwargs)
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
         except Exception:
             raise _ExpectedFailure(sys.exc_info())
@@ -35,7 +36,7 @@ class DeferrableTestCase(TestCase):
     def _executeTestPart(self, function, outcome, isTest=False):
         try:
             deferred = function()
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
         except KeyboardInterrupt:
             raise

--- a/unittesting/core/py33/suite.py
+++ b/unittesting/core/py33/suite.py
@@ -4,7 +4,7 @@ from unittest.suite import _DebugResult
 from unittest.suite import _isnotsuite
 from unittest.suite import TestSuite
 
-from ...utils import isiterable
+from .case import DeferrableMethod
 
 
 class DeferrableTestSuite(TestSuite):
@@ -20,13 +20,13 @@ class DeferrableTestSuite(TestSuite):
 
             if _isnotsuite(test):
                 deferred = self._tearDownPreviousClass(test, result)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
                 yield
                 self._handleModuleFixture(test, result)
                 yield
                 deferred = self._handleClassSetUp(test, result)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
                 yield
                 result._previousTestClass = test.__class__
@@ -40,14 +40,14 @@ class DeferrableTestSuite(TestSuite):
             else:
                 deferred = test.debug()
 
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
 
             yield
 
         if topLevel:
             deferred = self._tearDownPreviousClass(None, result)
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
             yield
             yield
@@ -77,7 +77,7 @@ class DeferrableTestSuite(TestSuite):
             _call_if_exists(result, '_setupStdout')
             try:
                 deferred = setUpClass()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             except Exception as e:
                 if isinstance(result, _DebugResult):
@@ -106,7 +106,7 @@ class DeferrableTestSuite(TestSuite):
             _call_if_exists(result, '_setupStdout')
             try:
                 deferred = tearDownClass()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             except Exception as e:
                 if isinstance(result, _DebugResult):

--- a/unittesting/core/py38/case.py
+++ b/unittesting/core/py38/case.py
@@ -1,10 +1,10 @@
 import sys
 
+from collections.abc import Generator as DeferrableMethod
 from unittest import TestCase
 from unittest.case import _Outcome
 from unittest.case import expectedFailure
 
-from ...utils import isiterable
 from .runner import defer
 
 __all__ = [
@@ -17,22 +17,22 @@ class DeferrableTestCase(TestCase):
 
     def _callSetUp(self):
         deferred = self.setUp()
-        if isiterable(deferred):
+        if isinstance(deferred, DeferrableMethod):
             yield from deferred
 
     def _callTestMethod(self, method):
         deferred = method()
-        if isiterable(deferred):
+        if isinstance(deferred, DeferrableMethod):
             yield from deferred
 
     def _callTearDown(self):
         deferred = self.tearDown()
-        if isiterable(deferred):
+        if isinstance(deferred, DeferrableMethod):
             yield from deferred
 
     def _callCleanup(self, function, *args, **kwargs):
         deferred = function(*args, **kwargs)
-        if isiterable(deferred):
+        if isinstance(deferred, DeferrableMethod):
             yield from deferred
 
     @staticmethod
@@ -71,22 +71,22 @@ class DeferrableTestCase(TestCase):
 
             with outcome.testPartExecutor(self):
                 deferred = self._callSetUp()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             if outcome.success:
                 outcome.expecting_failure = expecting_failure
                 with outcome.testPartExecutor(self, isTest=True):
                     deferred = self._callTestMethod(testMethod)
-                    if isiterable(deferred):
+                    if isinstance(deferred, DeferrableMethod):
                         yield from deferred
                 outcome.expecting_failure = False
                 with outcome.testPartExecutor(self):
                     deferred = self._callTearDown()
-                    if isiterable(deferred):
+                    if isinstance(deferred, DeferrableMethod):
                         yield from deferred
 
             deferred = self.doCleanups()
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
             for test, reason in outcome.skipped:
                 self._addSkip(result, test, reason)
@@ -123,7 +123,7 @@ class DeferrableTestCase(TestCase):
             function, args, kwargs = self._cleanups.pop()
             with outcome.testPartExecutor(self):
                 deferred = self._callCleanup(function, *args, **kwargs)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
 
         # return this for backwards compatibility
@@ -138,14 +138,14 @@ class DeferrableTestCase(TestCase):
             function, args, kwargs = cls._class_cleanups.pop()
             try:
                 deferred = function(*args, **kwargs)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             except Exception:
                 cls.tearDown_exceptions.append(sys.exc_info())
 
     def __call__(self, *args, **kwds):
         deferred = self.run(*args, **kwds)
-        if isiterable(deferred):
+        if isinstance(deferred, DeferrableMethod):
             yield from deferred
         else:
             return deferred

--- a/unittesting/core/py38/suite.py
+++ b/unittesting/core/py38/suite.py
@@ -4,7 +4,7 @@ from unittest.suite import _DebugResult
 from unittest.suite import _isnotsuite
 from unittest.suite import TestSuite
 
-from ...utils import isiterable
+from .case import DeferrableMethod
 
 
 class DeferrableTestSuite(TestSuite):
@@ -20,13 +20,13 @@ class DeferrableTestSuite(TestSuite):
 
             if _isnotsuite(test):
                 deferred = self._tearDownPreviousClass(test, result)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
                 yield
                 self._handleModuleFixture(test, result)
                 yield
                 deferred = self._handleClassSetUp(test, result)
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
                 yield
                 result._previousTestClass = test.__class__
@@ -43,14 +43,14 @@ class DeferrableTestSuite(TestSuite):
             if self._cleanup:
                 self._removeTestAtIndex(index)
 
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
 
             yield
 
         if topLevel:
             deferred = self._tearDownPreviousClass(None, result)
-            if isiterable(deferred):
+            if isinstance(deferred, DeferrableMethod):
                 yield from deferred
             yield
             yield
@@ -80,7 +80,7 @@ class DeferrableTestSuite(TestSuite):
             _call_if_exists(result, '_setupStdout')
             try:
                 deferred = setUpClass()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             except Exception as e:
                 if isinstance(result, _DebugResult):
@@ -94,7 +94,7 @@ class DeferrableTestSuite(TestSuite):
                 _call_if_exists(result, '_restoreStdout')
                 if currentClass._classSetupFailed is True:
                     deferred = currentClass.doClassCleanups()
-                    if isiterable(deferred):
+                    if isinstance(deferred, DeferrableMethod):
                         yield from deferred
                     if len(currentClass.tearDown_exceptions) > 0:
                         for exc in currentClass.tearDown_exceptions:
@@ -119,7 +119,7 @@ class DeferrableTestSuite(TestSuite):
             _call_if_exists(result, '_setupStdout')
             try:
                 deferred = tearDownClass()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
             except Exception as e:
                 if isinstance(result, _DebugResult):
@@ -131,7 +131,7 @@ class DeferrableTestSuite(TestSuite):
             finally:
                 _call_if_exists(result, '_restoreStdout')
                 deferred = previousClass.doClassCleanups()
-                if isiterable(deferred):
+                if isinstance(deferred, DeferrableMethod):
                     yield from deferred
                 if len(previousClass.tearDown_exceptions) > 0:
                     for exc in previousClass.tearDown_exceptions:

--- a/unittesting/helpers/override_preferences_test_cast.py
+++ b/unittesting/helpers/override_preferences_test_cast.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import sublime
 
+from ..core import DeferrableMethod
 from ..core import DeferrableTestCase
 
 
@@ -32,9 +33,9 @@ class OverridePreferencesTestCase(DeferrableTestCase):
             yield 500
             s.clear_on_change(on_change_key)
 
-        x = super().setUpClass()
-        if hasattr(x, '__iter__'):
-            yield from x
+        deferred = super().setUpClass()
+        if isinstance(deferred, DeferrableMethod):
+            yield from deferred
 
     @classmethod
     def tearDownClass(cls):
@@ -49,6 +50,6 @@ class OverridePreferencesTestCase(DeferrableTestCase):
                 except Exception:
                     pass
 
-        x = super().tearDownClass()
-        if hasattr(x, '__iter__'):
-            yield from x
+        deferred = super().tearDownClass()
+        if isinstance(deferred, DeferrableMethod):
+            yield from deferred

--- a/unittesting/helpers/temp_directory_test_case.py
+++ b/unittesting/helpers/temp_directory_test_case.py
@@ -3,6 +3,7 @@ import shutil
 import sublime
 import tempfile
 
+from ..core import DeferrableMethod
 from ..core import DeferrableTestCase
 
 
@@ -33,15 +34,15 @@ class TempDirectoryTestCase(DeferrableTestCase):
 
     @classmethod
     def setUpClass(cls):
-        """
-            Create a temp directory for testing.
-            Note that it is a generator, if you need to extend this method, you will
-            need to call
+        """Create a temp directory for testing.
 
-                yield from super().setUpClass()
+        Note that it is a DeferrableMethod, if you need to extend this method,
+        you will need to call
 
-            from the subclass. Note that if the subclass has multiple parents,
-            `super().setUpClass` may not be a generator at all depends on the order.
+            yield from super().setUpClass()
+
+        from the subclass. Note that if the subclass has multiple parents,
+        `super().setUpClass` may not be a DeferrableMethod at all depends on the order.
         """
         cls._temp_dir = tempfile.mkdtemp()
         nwindows = len(sublime.windows())
@@ -56,9 +57,9 @@ class TempDirectoryTestCase(DeferrableTestCase):
 
         yield from cls.setWindowFolder()
 
-        x = super().setUpClass()
-        if hasattr(x, '__iter__'):
-            yield from x
+        deferred = super().setUpClass()
+        if isinstance(deferred, DeferrableMethod):
+            yield from deferred
 
     @classmethod
     def tearDownClass(cls):
@@ -74,6 +75,6 @@ class TempDirectoryTestCase(DeferrableTestCase):
 
             sublime.set_timeout(remove_temp_dir, 1000)
 
-        x = super().tearDownClass()
-        if hasattr(x, '__iter__'):
-            yield from x
+        deferred = super().tearDownClass()
+        if isinstance(deferred, DeferrableMethod):
+            yield from deferred

--- a/unittesting/utils/__init__.py
+++ b/unittesting/utils/__init__.py
@@ -2,7 +2,6 @@ from .json_file import JsonFile
 from .output_panel import OutputPanel
 from .progress_bar import ProgressBar
 from .stdio_splitter import StdioSplitter
-from .isiterable import isiterable
 from .reloader import reload_package
 
 __all__ = [
@@ -10,6 +9,5 @@ __all__ = [
     "OutputPanel",
     "StdioSplitter",
     "ProgressBar",
-    "isiterable",
     "reload_package"
 ]

--- a/unittesting/utils/isiterable.py
+++ b/unittesting/utils/isiterable.py
@@ -1,2 +1,0 @@
-def isiterable(obj):
-    return hasattr(obj, '__iter__')


### PR DESCRIPTION
Use `isinstance(obj, Iterable)` to detect generator functions in python 3.3 environment and `isinstance(obj, Generator)` on python 3.8.
