### PR TITLE
Always start coverage after reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ UnitTesting could be configured by providing the following settings in `unittest
 | show_reload_progress        | print a detailed list of reloaded modules to console                              | false         |
 | coverage                    | track test case coverage                                                          | false         |
 | coverage_on_worker_thread   | (experimental)                                                                    | false         |
-| start_coverage_after_reload | self explained, irrelevent if `coverage` or `reload_package_on_testing` are false | false         |
 | generate_html_report        | generate HTML report for coverage                                                 | false         |
 | generate_xml_report         | generate XML report for coverage                                                  | false         |
 

--- a/unittesting/base.py
+++ b/unittesting/base.py
@@ -27,7 +27,6 @@ DEFAULT_SETTINGS = {
     "show_reload_progress": False,
     # coverage
     "coverage": False,
-    "start_coverage_after_reload": False,
     "coverage_on_worker_thread": False,   # experimental
     "generate_html_report": False,
     "generate_xml_report": False,

--- a/unittesting/unit.py
+++ b/unittesting/unit.py
@@ -102,12 +102,12 @@ class UnitTestingCommand(BaseUnittestingCommand):
             self.run_coverage(package, stream, settings)
 
     def run_coverage(self, package, stream, settings):
+        if settings["reload_package_on_testing"]:
+            reload_package(package)
+
         if not coverage or not settings["coverage"]:
             if settings["coverage"]:
                 stream.write("Warning: coverage cannot be loaded.\n\n")
-
-            if settings["reload_package_on_testing"]:
-                reload_package(package, verbose=settings["show_reload_progress"])
 
             self.run_tests(stream, package, settings, [])
             return
@@ -136,12 +136,7 @@ class UnitTestingCommand(BaseUnittestingCommand):
             data_file=data_file, config_file=config_file, include=include, omit=omit
         )
 
-        if not settings["start_coverage_after_reload"]:
-            cov.start()
-        if settings["reload_package_on_testing"]:
-            reload_package(package, verbose=settings["show_reload_progress"])
-        if settings["start_coverage_after_reload"]:
-            cov.start()
+        cov.start()
 
         if settings["coverage_on_worker_thread"]:
             import threading


### PR DESCRIPTION
If coverage tracking is started before reloading plugins, all modules which are reloaded (but maybe not tested) are recorded, which creates a wrong result.

Thus the option `start_coverage_after_reload` is dropped and its behavior made the default.