### PR TITLE
Fix plugin reloading before test start

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ UnitTesting could be configured by providing the following settings in `unittest
 | verbosity                   | verbosity level                                                                   | 2             |
 | capture_console             | capture stdout and stderr in the test output                                      | false         |
 | reload_package_on_testing   | reloading package will increase coverage rate                                     | true          |
-| show_reload_progress        | print a detailed list of reloaded modules to console                              | false         |
 | coverage                    | track test case coverage                                                          | false         |
 | coverage_on_worker_thread   | (experimental)                                                                    | false         |
 | generate_html_report        | generate HTML report for coverage                                                 | false         |

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -35,10 +35,6 @@
               "type": ["string", "null"],
               "markdownDescription": "Name of the test output instead of showing in the panel.",
             },
-            "show_reload_progress": {
-              "type": "boolean",
-              "default": true,
-            },
             "reload_package_on_testing": {
               "type": "boolean",
               "default": true,
@@ -48,11 +44,6 @@
               "type": "boolean",
               "default": false,
               "markdownDescription": "Create coverage report.",
-            },
-            "start_coverage_after_reload": {
-              "type": "boolean",
-              "default": false,
-              "markdownDescription": "Irrelevent if  `reload_package_on_testing` is false.",
             },
             "coverage_on_worker_thread": {
               "type": "boolean",

--- a/unittesting/base.py
+++ b/unittesting/base.py
@@ -24,7 +24,6 @@ DEFAULT_SETTINGS = {
     "capture_console": False,
     # reloader
     "reload_package_on_testing": True,
-    "show_reload_progress": False,
     # coverage
     "coverage": False,
     "coverage_on_worker_thread": False,   # experimental


### PR DESCRIPTION
This commit ...

1. refactors reloader's dummy plugin install/removal by using set_timeout() to check for dummy being loaded in order to not block the calling thread.
2. uses an `on_done` callback to continue operation after dummy has been removed.
3. always loads a dummy plugin as it is required to teach ST about new command and event instances. It does not work without that step.

Before this commit the whole UI thread was blocked, causing dummy plugin not being reloaded until timeout was hit. Running tests on worker thread had other negative impacts.

Reloading now behaves like "DefferableTextTestRunner" using set_timeout to schedule coroutines.