### PR TITLE
Fix circular import due to DeferrableTestSuite

### DIFF
--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -4,6 +4,7 @@ if sys.version_info >= (3, 8):
     from .py38.case import DeferrableMethod
     from .py38.case import DeferrableTestCase
     from .py38.case import expectedFailure
+    from .py38.loader import DeferrableTestLoader
     from .py38.runner import AWAIT_WORKER
     from .py38.runner import DeferringTextTestRunner
     from .py38.suite import DeferrableTestSuite
@@ -11,18 +12,17 @@ else:
     from .py33.case import DeferrableMethod
     from .py33.case import DeferrableTestCase
     from .py33.case import expectedFailure
+    from .py33.loader import DeferrableTestLoader
     from .py33.runner import AWAIT_WORKER
     from .py33.runner import DeferringTextTestRunner
     from .py33.suite import DeferrableTestSuite
-
-from .loader import UnitTestingLoader as TestLoader
 
 __all__ = [
     "AWAIT_WORKER",
     "DeferrableMethod",
     "DeferrableTestCase",
+    "DeferrableTestLoader",
     "DeferrableTestSuite",
     "DeferringTextTestRunner",
     "expectedFailure",
-    "TestLoader",
 ]

--- a/unittesting/core/py33/loader.py
+++ b/unittesting/core/py33/loader.py
@@ -1,10 +1,10 @@
 from unittest import TestSuite
 from unittest import TestLoader
 
-from . import DeferrableTestSuite
+from .suite import DeferrableTestSuite
 
 
-class UnitTestingLoader(TestLoader):
+class DeferrableTestLoader(TestLoader):
     def __init__(self, deferred=False):
         if deferred:
             self.suiteClass = DeferrableTestSuite

--- a/unittesting/core/py38/loader.py
+++ b/unittesting/core/py38/loader.py
@@ -1,0 +1,13 @@
+from unittest import TestSuite
+from unittest import TestLoader
+
+from .suite import DeferrableTestSuite
+
+
+class DeferrableTestLoader(TestLoader):
+    def __init__(self, deferred=False):
+        if deferred:
+            self.suiteClass = DeferrableTestSuite
+        else:
+            self.suiteClass = TestSuite
+        super().__init__()

--- a/unittesting/unit.py
+++ b/unittesting/unit.py
@@ -11,8 +11,8 @@ from unittest import TextTestRunner
 from .base import BaseUnittestingCommand
 from .base import DONE_MESSAGE
 from .core import DeferrableTestCase
+from .core import DeferrableTestLoader
 from .core import DeferringTextTestRunner
-from .core import TestLoader
 from .utils import reload_package
 from .utils import StdioSplitter
 
@@ -207,7 +207,7 @@ class UnitTestingCommand(BaseUnittestingCommand):
             if not is_empty_test:
                 # use custom loader which supports reloading modules
                 self.remove_test_modules(package, settings["tests_dir"])
-                loader = TestLoader(settings["deferred"])
+                loader = DeferrableTestLoader(settings["deferred"])
                 if os.path.exists(os.path.join(start_dir, "__init__.py")):
                     tests = loader.discover(
                         start_dir, settings["pattern"], top_level_dir=package_dir


### PR DESCRIPTION
This commit moves (duplicates) loader module into py33 and p38 packages and imports it from there to avoid a circular import.