### PR TITLE
Fix CI tests failing on MacOS ARM64

### DIFF
--- a/actions/setup/install_package_control_helper.py
+++ b/actions/setup/install_package_control_helper.py
@@ -61,7 +61,7 @@ def plugin_loaded():
         if missing_libraries:
             nonlocal num_retries
 
-            if num_retries < 3:
+            if num_retries < 10:
                 num_retries += 1
                 sublime.set_timeout(check_libraries, 2000)
                 return

--- a/actions/setup/install_package_control_helper.py
+++ b/actions/setup/install_package_control_helper.py
@@ -5,7 +5,9 @@ import sys
 
 
 def plugin_loaded():
-    package_path = os.path.join(sublime.packages_path(), "0_install_package_control_helper")
+    package_path = os.path.join(
+        sublime.packages_path(), "0_install_package_control_helper"
+    )
 
     logfile = os.path.join(package_path, "log")
 
@@ -67,7 +69,13 @@ def plugin_loaded():
                 return
 
             log.write("missing libraries:" + "\n")
-            log.write(" ".join(sorted(missing_libraries)) + "\n")
+            log.write(
+                "\n".join(
+                    "- {lib.name} for Python {lib.python_version}".format(lib)
+                    for lib in sorted(missing_libraries)
+                )
+                + "\n"
+            )
             touch("failed")
         else:
             touch("success")

--- a/plugin.py
+++ b/plugin.py
@@ -62,7 +62,18 @@ def plugin_loaded():
 
             try:
                 with open(os.path.join(UT33, "dependencies.json"), "x") as f:
-                    f.write(json.dumps({"*": {">3000": ["coverage"]}}))
+                    f.write(
+                        json.dumps(
+                            {
+                                "linux-x32": {">3000": ["coverage"]},
+                                "linux-x64": {">3000": ["coverage"]},
+                                "osx-x32": {">3000": ["coverage"]},
+                                "osx-x32": {">3000": ["coverage"]},
+                                "windows-x32": {">3000": ["coverage"]},
+                                "windows-x64": {">3000": ["coverage"]},
+                            }
+                        )
+                    )
             except FileExistsError:
                 pass
 


### PR DESCRIPTION
Fixes #265

Github Actions started to run on MacOS ARM64. Neither "coverage" nor any other legacy dependency or library shipping platform-specific binaries support arm64 on python 3.3

As a result running CI tests on MacOS requires either explicitly requesting x64 platform or must not use platform-specific python 3.3 dependendencies/libraries.

This PR therefore excludes coverage dependency on arm64 platforms for python 3.3