### PR TITLE
Add new 'warnings' setting + enable warnings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ window.run_command("unit_testing", {"package": "$package_name", "coverage": Fals
 | pattern                     | the pattern to discover tests                                | "test*.py"    |
 | deferred                    | whether to use deferred test runner                          | true          |
 | condition_timeout           | default timeout in ms for callables invoked via `yield`      | 4000          |
+| warnings                    | the warnings level (defaults to print warnings in console)   | "default"     |
 | failfast                    | stop early if a test fails                                   | false         |
 | output                      | name of the test output instead of showing <br> in the panel | null          |
 | verbosity                   | verbosity level                                              | 2             |

--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ window.run_command("unit_testing", {"package": "$package_name", "coverage": Fals
 | pattern                     | the pattern to discover tests                                | "test*.py"    |
 | deferred                    | whether to use deferred test runner                          | true          |
 | condition_timeout           | default timeout in ms for callables invoked via `yield`      | 4000          |
-| warnings                    | the warnings level (defaults to print warnings in console)   | "default"     |
 | failfast                    | stop early if a test fails                                   | false         |
 | output                      | name of the test output instead of showing <br> in the panel | null          |
 | verbosity                   | verbosity level                                              | 2             |
+| warnings                    | The warnings filter controls python warnings treatment.      | "default"     |
 | capture_console             | capture stdout and stderr in the test output                 | false         |
 | reload_package_on_testing   | reloading package will increase coverage rate                | true          |
 | coverage                    | track test case coverage                                     | false         |
@@ -325,6 +325,18 @@ window.run_command("unit_testing", {"package": "$package_name", "coverage": Fals
 | generate_html_report        | generate HTML report for coverage                            | false         |
 | generate_xml_report         | generate XML report for coverage                             | false         |
 
+Valid `warnings` values are:
+
+| Value     | Disposition
+| --------- | -----------
+| "default" | print the first occurrence of matching warnings for each location (module + line number) where the warning is issued
+| "error"   | turn matching warnings into exceptions
+| "ignore"  | never print matching warnings
+| "always"  | always print matching warnings
+| "module"  | print the first occurrence of matching warnings for each module where the warning is issued (regardless of line number)
+| "once"    | print only the first occurrence of matching warnings, regardless of location
+
+see also: https://docs.python.org/3/library/warnings.html#warning-filter
 
 ## Writing Unittests
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -31,6 +31,19 @@
               "default": 2,
               "markdownDescription": "Verbosity level.",
             },
+            "warnings": {
+              "enum": ["default", "error", "ignore", "always", "module", "once"],
+              "enumDescriptions": [
+                "print the first occurrence of matching warnings for each location (module + line number) where the warning is issued",
+                "turn matching warnings into exceptions",
+                "never print matching warnings",
+                "always print matching warnings",
+                "print the first occurrence of matching warnings for each module where the warning is issued (regardless of line number)",
+                "print only the first occurrence of matching warnings, regardless of location"
+              ],
+              "default": "default",
+              "markdownDescription": "The warnings filter controls whether warnings are ignored, displayed, or turned into errors (raising an exception).",
+            },
             "output": {
               "type": ["string", "null"],
               "markdownDescription": "Name of the test output instead of showing in the panel.",

--- a/unittesting/base.py
+++ b/unittesting/base.py
@@ -17,6 +17,7 @@ DEFAULT_SETTINGS = {
     "deferred": True,
     "condition_timeout": 4000,
     "failfast": False,
+    "warnings": "default",
     # output
     "output": None,
     "verbosity": 2,

--- a/unittesting/base.py
+++ b/unittesting/base.py
@@ -17,10 +17,10 @@ DEFAULT_SETTINGS = {
     "deferred": True,
     "condition_timeout": 4000,
     "failfast": False,
-    "warnings": "default",
     # output
     "output": None,
     "verbosity": 2,
+    "warnings": "default",
     "capture_console": False,
     # reloader
     "reload_package_on_testing": True,

--- a/unittesting/unit.py
+++ b/unittesting/unit.py
@@ -223,6 +223,7 @@ class UnitTestingCommand(BaseUnittestingCommand):
                     testRunner = DeferringTextTestRunner(
                         stream=stream,
                         verbosity=settings["verbosity"],
+                        warnings=settings["warnings"],
                         failfast=settings["failfast"],
                         condition_timeout=settings["condition_timeout"],
                     )
@@ -231,6 +232,7 @@ class UnitTestingCommand(BaseUnittestingCommand):
                     testRunner = TextTestRunner(
                         stream,
                         verbosity=settings["verbosity"],
+                        warnings=settings["warnings"],
                         failfast=settings["failfast"],
                     )
 


### PR DESCRIPTION
See https://github.com/SublimeText/UnitTesting/issues/271. With this, the test runner will print warnings (ResourceWarning, DeprecationWarning, etc.) in the console by default.
