### PR TITLE
Make version checks in __init__ type-checker friendly

### DIFF
--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info[:2] >= (3, 13):
+if sys.version_info >= (3, 13):
     from .py313.case import DeferrableMethod
     from .py313.case import DeferrableTestCase
     from .py313.case import IsolatedAsyncioTestCase
@@ -10,7 +10,7 @@ if sys.version_info[:2] >= (3, 13):
     from .py313.runner import AWAIT_WORKER
     from .py313.runner import DeferringTextTestRunner
     from .py313.suite import DeferrableTestSuite
-elif sys.version_info[:2] == (3, 8):
+elif sys.version_info == (3, 8):
     from .py38.case import DeferrableMethod
     from .py38.case import DeferrableTestCase
     from .py38.case import IsolatedAsyncioTestCase
@@ -20,7 +20,7 @@ elif sys.version_info[:2] == (3, 8):
     from .py38.runner import AWAIT_WORKER
     from .py38.runner import DeferringTextTestRunner
     from .py38.suite import DeferrableTestSuite
-elif sys.version_info[:2] == (3, 3):
+elif sys.version_info == (3, 3):
     from .py33.case import DeferrableMethod
     from .py33.case import DeferrableTestCase
     from .py33.case import IsolatedAsyncioTestCase

--- a/unittesting/core/__init__.py
+++ b/unittesting/core/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 13):
     from .py313.runner import AWAIT_WORKER
     from .py313.runner import DeferringTextTestRunner
     from .py313.suite import DeferrableTestSuite
-elif sys.version_info == (3, 8):
+elif sys.version_info >= (3, 8):
     from .py38.case import DeferrableMethod
     from .py38.case import DeferrableTestCase
     from .py38.case import IsolatedAsyncioTestCase
@@ -20,7 +20,7 @@ elif sys.version_info == (3, 8):
     from .py38.runner import AWAIT_WORKER
     from .py38.runner import DeferringTextTestRunner
     from .py38.suite import DeferrableTestSuite
-elif sys.version_info == (3, 3):
+elif sys.version_info >= (3, 3):
     from .py33.case import DeferrableMethod
     from .py33.case import DeferrableTestCase
     from .py33.case import IsolatedAsyncioTestCase


### PR DESCRIPTION
Slightly change how `sys.version_info` is compared to make it type-checker (pyright) friendly. With the old way it's not able to correctly infer which block is used so it evaluates the code of the 3.3 runtime.

To test set pyright settings like:

```jsonc
				"settings": {
					"pyright.analysis.extraPaths": [
						// Expose `UnitTesting/unittesting` module.
						"<full-profile-path>/Packages/UnitTesting"
					],
					"pyright.dev_environment": "sublime_text_38"
				}
```

and then "go to definition" of a `DeferrableTestCase` symbol from some test in that package.